### PR TITLE
chore: move pr check jobs to own workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,17 @@
+name: PR Checks
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+      - name: Install dependencies and build
+        run: npm ci
+      - name: Test run build-docs
+        run: npm run build-docs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,16 +5,14 @@ name: Deploy to GithHub Pages
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: '16.x'
     - name: Run npm run deploy


### PR DESCRIPTION
Summary
=======

The current GitHub Actions workflow is triggering on PRs targeting the main branch, which causes gh pages to attempt to deploy each PR. This is problematic both for PRs from forks and dependabot, as those PRs will not have permissions to deploy to gh pages, and it would result in PRs that have not yet been approved to override the existing deployment on gh pages.

This change removes the pr trigger from the publish workflow and adds a new workflow for checking prs. Currently this only tests that the PR builds both the njwds assets and the associated docs (there are no current tests to run in addition).

Test Plan
========

This PR should serve as its own test. 
