### PR TITLE
fix: copy missing uswds js files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -80,7 +80,7 @@ gulp.task("copy-src-images", () => {
 
 
 gulp.task("copy-uswds-js", () => {
-  return gulp.src(`${uswds}/js/**/**`).pipe(gulp.dest(`${JS_DEST}`));
+  return gulp.src(`${uswds}/dist/js/**/**`).pipe(gulp.dest(`${JS_DEST}`));
 });
 
 gulp.task("build-sass", function(done) {


### PR DESCRIPTION
Summary
=======

During the upgrade to uswds version 3.0.1 in 5ee0e83fbeab63ef5da9ba2204b6a00806045af0, we updated the source directories for images and fonts, but missed the javascript directory change. This is causing some components to not act correctly (for example the accordions at https://newjersey.github.io/njwds/components/detail/accordion--default.html stay fully expanded on load and cannot collapse).

<img width="2278" alt="Screen Shot 2022-09-23 at 1 29 04 PM" src="https://user-images.githubusercontent.com/121035/192024084-090ed8f8-1cd6-4683-8aef-ec2c551fdf47.png">


This applies the same fix from those directories to the js directory for uswds.

Test Plan
========

Run build locally and confirmed that the js files appear again in the dist folder.

I also ran `npm run build-docs` locally and opened the Borderless Accordion example (at build/components/detail/accordion--default.html), and made sure the accordions work again.

<img width="2290" alt="Screen Shot 2022-09-23 at 1 29 24 PM" src="https://user-images.githubusercontent.com/121035/192024134-610dbd9c-c48a-4783-98b6-b8858881aa86.png">
