### PR TITLE
feat: create initial release infra for npm packages

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -39,6 +39,9 @@ jobs:
     needs: update-version
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.update-version.outputs.release_sha }}
       - run: |
           gh release create ${{ needs.update-version.outputs.new_version }} \
           --draft \

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,46 @@
+name: Draft release
+on:
+  workflow_dispatch:
+    inputs:
+      semver_release_type:
+        description: SemVer Level for this Release
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+      - run: npm ci
+      - name: Bump and commit new version
+        id: bump_version
+        run: |
+          NEW_VERSION=$(npm version ${{ inputs.semver_release_type }} --no-git-tag-version)
+          git add package.json
+          git commit -m "Bump version to $NEW_VERSION" --author "NJWDS Draft Release Action <>"
+          git push
+          RELEASE_SHA=$(git rev-parse HEAD)
+          echo ::set-output name=new_version::$NEW_VERSION
+          echo ::set-output name=release_sha::$RELEASE_SHA
+    outputs:
+      new_version: ${{ steps.bump_version.outputs.new_version }}
+      release_sha: ${{ steps.bump_version.outputs.release_sha }}
+
+  draft-release:
+    needs: update-version
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          gh release create ${{ needs.update-version.outputs.new_version }} \
+          --draft \
+          --generate-notes \
+          --target ${{ needs.update-version.outputs.release_sha }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,20 @@
+name: Publish Release
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup npm to publish to npmjs
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "njwds",
+  "name": "@newjersey/njwds",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "njwds",
+      "name": "@newjersey/njwds",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "njwds",
+  "name": "@newjersey/njwds",
   "version": "0.1.0",
   "description": "NJ Web Design Standards",
   "main": "index.js",


### PR DESCRIPTION
Summary
=======

Creates the initial release pipelines for triggering npm package publishing.

The basic pipeline is:
1. Someone with write permission to the repository triggers the draft-release workflow to bump the npm package version and create a Draft Release in GitHub.
2. When someone later publishes the Release in GitHub, the publish-release workflow will then trigger a publish to NPM for that package.

Test Plan
=========

Unfortuatately this is something that will need to be tested after merging. Someone with admin permissions to this GitHub repo will need to add the NPM_TOKEN secret for an npm auth token that has permission to publish to the newjersey organization in npmjs. Then we can try triggering a draft release and publishing it to create the first package in npmjs.

