### PR TITLE
fix: draft release flow

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -20,14 +20,13 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16.x'
-      - run: npm ci
       - name: Bump and commit new version
         id: bump_version
         run: |
           git config --global user.email "<>"
           git config --global user.name "NJWDS Draft Release Action"
           NEW_VERSION=$(npm version ${{ inputs.semver_release_type }} --no-git-tag-version)
-          git add package.json
+          git add package.json package-lock.json
           git commit -m "Bump version to $NEW_VERSION"
           git push
           RELEASE_SHA=$(git rev-parse HEAD)
@@ -49,3 +48,5 @@ jobs:
           --draft \
           --generate-notes \
           --target ${{ needs.update-version.outputs.release_sha }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newjersey/njwds",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "description": "NJ Web Design Standards",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
1. Ensures that the package-lock.json is commit also with version bump.
2. Removes unneeded dependency install when bumping npm version.
3. Adds missing GH_TOKEN environment variable for gh release creation.

