### PR TITLE
Add env token to Github Action draft release

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: "16.x"
       - name: Bump and commit new version
         id: bump_version
         run: |
@@ -32,6 +32,8 @@ jobs:
           RELEASE_SHA=$(git rev-parse HEAD)
           echo ::set-output name=new_version::$NEW_VERSION
           echo ::set-output name=release_sha::$RELEASE_SHA
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       new_version: ${{ steps.bump_version.outputs.new_version }}
       release_sha: ${{ steps.bump_version.outputs.release_sha }}


### PR DESCRIPTION
Github Action can no longer push to the `main` branch since it is protected. Adding environment access token to hopefully allow it to write, which is needed to automatically bump version in package.json file