### PR TITLE
Use deploy key in Github Actions draft release

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ssh-key: ${{secrets.YOUR_SECRET_KEY}}
       - uses: actions/setup-node@v3
         with:
           node-version: "16.x"
@@ -32,8 +34,6 @@ jobs:
           RELEASE_SHA=$(git rev-parse HEAD)
           echo ::set-output name=new_version::$NEW_VERSION
           echo ::set-output name=release_sha::$RELEASE_SHA
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       new_version: ${{ steps.bump_version.outputs.new_version }}
       release_sha: ${{ steps.bump_version.outputs.release_sha }}
@@ -45,6 +45,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ needs.update-version.outputs.release_sha }}
+          ssh-key: ${{secrets.YOUR_SECRET_KEY}}
       - run: |
           gh release create ${{ needs.update-version.outputs.new_version }} \
           --draft \


### PR DESCRIPTION
the Draft Release Github Action is not able to use `git push` to `main` branch because it is a protected branch by default. Based on some suggestions on StackOverflow, I've added a "deploy key" and am giving the Github Action that scope to hopefully bypass branch protections https://stackoverflow.com/questions/69263843/how-to-push-to-protected-main-branches-in-a-github-action