### PR TITLE
fix uswds config to have $text-align-settings.responsive = true

### DIFF
--- a/src/sass/_uswds-theme.scss
+++ b/src/sass/_uswds-theme.scss
@@ -120,5 +120,13 @@
   // Type Scale
   $theme-type-scale-md: 7,
   // Headings
-  $theme-h4-font-size: "md"
+  $theme-h4-font-size: "md",
+
+  /*
+  ----------------------------------------
+  Configuration settings
+  ----------------------------------------
+  */
+  // Text align settings
+   $text-align-settings: (responsive: true)
 );

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -9,14 +9,6 @@
 */
 
 // -------------------------------------
-// Configuration settings
-@use "uswds-core" with (
-  $text-align-settings: (
-    responsive: true
-  )
-);
-
-// -------------------------------------
 // Import individual theme settings
 @forward "uswds-theme";
 


### PR DESCRIPTION
Goal is to allow for responsive text align which requires config change in [uswds](https://designsystem.digital.gov/utilities/paragraph-styles/). Adjusting scss files to allow for this