### PR TITLE
added permissions to publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js 16.x


### PR DESCRIPTION
build process has been failing for the last few commits, there is a 403 error (example job [here](https://github.com/newjersey/njwds/actions/runs/10796868979/job/29946842435)). Giving access to github actions to fix.  