### PR TITLE
Feat: update button styling for new njwds design

### DIFF
--- a/src/components/02-buttons/buttons.config.yml
+++ b/src/components/02-buttons/buttons.config.yml
@@ -1,19 +1,13 @@
 label: Buttons
 status: ready
-
+default: Primary (Light)
 variants:
-
-  - name: Primary (Light)
-    context:
-      category: primary
-      label: Primary Buttons (Light)
-      classes: "usa-button"
 
   - name: Primary (Dark)
     context:
       category: primary
       label: Primary Buttons (Dark)
-      classes: "usa-button primary-button-dark"
+      classes: "primary-button-dark"
 
   - name: Primary (Danger)
     context:

--- a/src/components/02-buttons/buttons.config.yml
+++ b/src/components/02-buttons/buttons.config.yml
@@ -2,44 +2,56 @@ label: Buttons
 status: ready
 
 variants:
-  - name: secondary
+
+  - name: Primary (Light)
     context:
-      category: alternate
-      label: Secondary buttons
+      category: primary
+      label: Primary Buttons (Light)
+      classes: "usa-button"
+
+  - name: Primary (Dark)
+    context:
+      category: primary
+      label: Primary Buttons (Dark)
+      classes: "usa-button primary-button-dark"
+
+  - name: Primary (Danger)
+    context:
+      category: primary
+      label: Primary Buttons (Danger)
       classes: "usa-button--secondary"
 
-  - name: accent-cool
+  - name: secondary (Light)
     context:
-      category: alternate
-      label: Accent cool buttons
-      classes: "usa-button--accent-cool"
-
-  - name: accent-warm
-    context:
-      category: alternate
-      label: Accent warm buttons
-      classes: "usa-button--accent-warm"
-
-  - name: base
-    context:
-      category: alternate
-      label: Gray buttons
-      classes: "usa-button--base"
-
-  - name: outline
-    context:
-      category: outline
-      label: outline buttons
+      category: secondary
+      label: Secondary Buttons (Light)
       classes: "usa-button--outline"
 
-  - name: outline-inverse
+  - name: Secondary (Dark)
     context:
-      category: outline-inverse
-      label: outline inverse buttons
+      category: secondary
+      label: Secondary Buttons (Dark)
       classes: "usa-button--outline usa-button--inverse"
 
-  - name: big
+  - name: Secondary (Danger)
     context:
-      category: "big"
-      label: Big button
-      classes: "usa-button--big"
+      category: secondary
+      label: Secondary Buttons (Danger)
+      classes: "usa-button--outline outline-danger"
+
+  - name: Tertiary (Light)
+    context:
+      category: Tertiary/Danger
+      label: Tertiary/Link Light Buttons
+      classes: "usa-button--unstyled"
+
+  - name: Tertiary (Dark)
+    context:
+      category: Tertiary/Link
+      label: Tertiary/Link Dark Buttons
+      classes: "usa-button--unstyled unstyled-button-dark"
+  - name: Tertiary (Danger) 
+    context:
+      category: Tertiary/Danger
+      label: Tertiary/Link Danger Buttons
+      classes: "usa-button--unstyled unstyled-button-danger"

--- a/src/components/02-buttons/buttons.config.yml
+++ b/src/components/02-buttons/buttons.config.yml
@@ -15,7 +15,7 @@ variants:
       label: Primary Buttons (Danger)
       classes: "usa-button--secondary"
 
-  - name: secondary (Light)
+  - name: Secondary (Light)
     context:
       category: secondary
       label: Secondary Buttons (Light)
@@ -44,6 +44,7 @@ variants:
       category: Tertiary/Link
       label: Tertiary/Link Dark Buttons
       classes: "usa-button--unstyled unstyled-button-dark"
+
   - name: Tertiary (Danger) 
     context:
       category: Tertiary/Danger

--- a/src/components/02-buttons/buttons.njk
+++ b/src/components/02-buttons/buttons.njk
@@ -1,25 +1,28 @@
-{%- if (classes == 'usa-button primary-button-dark') or (classes == 'usa-button--outline usa-button--inverse') or (classes == 'usa-button--unstyled unstyled-button-dark') -%}
+{%- set buttonClasses = 'usa-button ' + (classes | default('')) -%}
+
+{%- if (label == 'Secondary Buttons (Dark)') or (label == 'Primary Buttons (Dark)') or (label == 'Tertiary/Link Dark Buttons') -%}
 <div class="bg-base-darkest padding-1" style="max-width: fit-content">
 {% else -%}
 <div class="padding-1" style="max-width: fit-content">
 {% endif -%}
-  <button class="usa-button {{ classes }}">Default</button>
-  <button class="usa-button {{ classes }} usa-button--hover">Hover</button>
-  <button class="usa-button {{ classes }} usa-button--active">Active</button>
-  <button class="usa-button {{ classes }} usa-focus">Focus</button>
-  <button class="usa-button {{ classes }} button-icon icon-trailing">
+
+  <button class="{{ buttonClasses | trim }}">Default</button>
+  <button class="{{ buttonClasses | trim }} usa-button--hover">Hover</button>
+  <button class="{{ buttonClasses | trim }} usa-button--active">Active</button>
+  <button class="{{ buttonClasses | trim }} usa-focus">Focus</button>
+  <button class="{{ buttonClasses | trim }} button-icon">
     Icon Trailing
     <svg class="usa-icon usa-icon--size-3 margin-left-105" aria-hidden="true" focusable="false" role="img">
       <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
     </svg>
   </button>
-  <button class="usa-button {{ classes }} button-icon icon-leadng">
+  <button class="{{ buttonClasses | trim }} button-icon">
     <svg class="usa-icon usa-icon--size-3 margin-right-105" aria-hidden="true" focusable="false" role="img">
       <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
     </svg>
     Icon Leading
   </button>
-  <button aria-label="icon-label" class="usa-button {{ classes }} button-icon icon-only">
+  <button aria-label="icon-label" class="{{ buttonClasses | trim }} button-icon">
     <svg class="usa-icon usa-icon--size-3" focusable="false" role="img">
       <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
     </svg>

--- a/src/components/02-buttons/buttons.njk
+++ b/src/components/02-buttons/buttons.njk
@@ -1,28 +1,27 @@
 {%- if (classes == 'usa-button primary-button-dark') or (classes == 'usa-button--outline usa-button--inverse') or (classes == 'usa-button--unstyled unstyled-button-dark') -%}
 <div class="bg-base-darkest padding-1" style="max-width: fit-content">
+{% else -%}
+<div class="padding-1" style="max-width: fit-content">
 {% endif -%}
-
-<button class="usa-button {{ classes }}">Default</button>
-{% if (category != 'disabled') and (category != 'big') -%}
-<button class="usa-button {{ classes }} usa-button--hover">Hover</button>
-<button class="usa-button {{ classes }} usa-button--active">Active</button>
-<button class="usa-button {{ classes }} usa-focus">Focus</button>
-<button class="usa-button {{ classes }} button-icon icon-trailing">
-  Icon Trailing
-  <svg class="usa-icon usa-icon--size-3 margin-left-105" aria-hidden="true" focusable="false" role="img">
-    <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
-  </svg> </button>
-<button class="usa-button {{ classes }} button-icon icon-leadng">
-  <svg class="usa-icon usa-icon--size-3 margin-right-105" aria-hidden="true" focusable="false" role="img">
-    <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
-  </svg>Icon Leading  </button>
-<button aria-label="icon-label" class="usa-button {{ classes }} button-icon icon-only">
-  <svg class="usa-icon usa-icon--size-3" focusable="false" role="img">
-    <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
-  </svg></button>
-
-{%- endif -%}
-
-{%- if (classes == 'usa-button primary-button-dark') or (classes == 'usa-button--outline usa-button--inverse') or (classes == 'usa-button--unstyled unstyled-button-dark') -%}
+  <button class="usa-button {{ classes }}">Default</button>
+  <button class="usa-button {{ classes }} usa-button--hover">Hover</button>
+  <button class="usa-button {{ classes }} usa-button--active">Active</button>
+  <button class="usa-button {{ classes }} usa-focus">Focus</button>
+  <button class="usa-button {{ classes }} button-icon icon-trailing">
+    Icon Trailing
+    <svg class="usa-icon usa-icon--size-3 margin-left-105" aria-hidden="true" focusable="false" role="img">
+      <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
+    </svg>
+  </button>
+  <button class="usa-button {{ classes }} button-icon icon-leadng">
+    <svg class="usa-icon usa-icon--size-3 margin-right-105" aria-hidden="true" focusable="false" role="img">
+      <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
+    </svg>
+    Icon Leading
+  </button>
+  <button aria-label="icon-label" class="usa-button {{ classes }} button-icon icon-only">
+    <svg class="usa-icon usa-icon--size-3" focusable="false" role="img">
+      <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
+    </svg>
+  </button>
 </div>
-{%- endif %}

--- a/src/components/02-buttons/buttons.njk
+++ b/src/components/02-buttons/buttons.njk
@@ -1,4 +1,4 @@
-{%- if (classes == 'usa-button--outline usa-button--inverse') -%}
+{%- if (classes == 'usa-button primary-button-dark') or (classes == 'usa-button--outline usa-button--inverse') or (classes == 'usa-button--unstyled unstyled-button-dark') -%}
 <div class="bg-base-darkest padding-1" style="max-width: fit-content">
 {% endif -%}
 
@@ -9,8 +9,7 @@
 <button class="usa-button {{ classes }} usa-focus">Focus</button>
 <button class="usa-button {{ classes }}" disabled>Disabled</button>
 {%- endif -%}
-<button class="usa-button {{ classes }} usa-button--unstyled">Unstyled button</button>
 
-{%- if (classes == 'usa-button--outline usa-button--inverse') %}
+{%- if (classes == 'usa-button primary-button-dark') or (classes == 'usa-button--outline usa-button--inverse') or (classes == 'usa-button--unstyled unstyled-button-dark') -%}
 </div>
 {%- endif %}

--- a/src/components/02-buttons/buttons.njk
+++ b/src/components/02-buttons/buttons.njk
@@ -7,7 +7,20 @@
 <button class="usa-button {{ classes }} usa-button--hover">Hover</button>
 <button class="usa-button {{ classes }} usa-button--active">Active</button>
 <button class="usa-button {{ classes }} usa-focus">Focus</button>
-<button class="usa-button {{ classes }}" disabled>Disabled</button>
+<button class="usa-button {{ classes }} button-icon icon-trailing">
+  Icon Trailing
+  <svg class="usa-icon usa-icon--size-3 margin-left-105" aria-hidden="true" focusable="false" role="img">
+    <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
+  </svg> </button>
+<button class="usa-button {{ classes }} button-icon icon-leadng">
+  <svg class="usa-icon usa-icon--size-3 margin-right-105" aria-hidden="true" focusable="false" role="img">
+    <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
+  </svg>Icon Leading  </button>
+<button aria-label="icon-label" class="usa-button {{ classes }} button-icon icon-only">
+  <svg class="usa-icon usa-icon--size-3" focusable="false" role="img">
+    <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
+  </svg></button>
+
 {%- endif -%}
 
 {%- if (classes == 'usa-button primary-button-dark') or (classes == 'usa-button--outline usa-button--inverse') or (classes == 'usa-button--unstyled unstyled-button-dark') -%}

--- a/src/components/icon/icon.config.yml
+++ b/src/components/icon/icon.config.yml
@@ -1,0 +1,2 @@
+label: Icon
+status: ready

--- a/src/components/icon/icon.njk
+++ b/src/components/icon/icon.njk
@@ -1,0 +1,27 @@
+<svg class="usa-icon usa-icon--size-3" focusable="false" role="img">
+  <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
+</svg>
+
+<svg class="usa-icon usa-icon--size-4" focusable="false" role="img">
+  <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
+</svg>
+
+<svg class="usa-icon usa-icon--size-5" focusable="false" role="img">
+  <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
+</svg>
+
+<svg class="usa-icon usa-icon--size-6" focusable="false" role="img">
+  <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
+</svg>
+
+<svg class="usa-icon usa-icon--size-7" focusable="false" role="img">
+  <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
+</svg>
+
+<svg class="usa-icon usa-icon--size-8" focusable="false" role="img">
+  <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
+</svg>
+
+<svg class="usa-icon usa-icon--size-9" focusable="false" role="img">
+  <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
+</svg>

--- a/src/components/icon/icon.njk
+++ b/src/components/icon/icon.njk
@@ -1,27 +1,27 @@
-<svg class="usa-icon usa-icon--size-3" focusable="false" role="img">
+<svg class="usa-icon usa-icon--size-3" focusable="false" aria-hidden="true" role="img">
   <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
 </svg>
 
-<svg class="usa-icon usa-icon--size-4" focusable="false" role="img">
+<svg class="usa-icon usa-icon--size-4" focusable="false" aria-hidden="true" role="img">
   <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
 </svg>
 
-<svg class="usa-icon usa-icon--size-5" focusable="false" role="img">
+<svg class="usa-icon usa-icon--size-5" focusable="false" aria-hidden="true" role="img">
   <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
 </svg>
 
-<svg class="usa-icon usa-icon--size-6" focusable="false" role="img">
+<svg class="usa-icon usa-icon--size-6" focusable="false" aria-hidden="true" role="img">
   <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
 </svg>
 
-<svg class="usa-icon usa-icon--size-7" focusable="false" role="img">
+<svg class="usa-icon usa-icon--size-7" focusable="false" aria-hidden="true" role="img">
   <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
 </svg>
 
-<svg class="usa-icon usa-icon--size-8" focusable="false" role="img">
+<svg class="usa-icon usa-icon--size-8" focusable="false" aria-hidden="true" role="img">
   <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
 </svg>
 
-<svg class="usa-icon usa-icon--size-9" focusable="false" role="img">
+<svg class="usa-icon usa-icon--size-9" focusable="false" aria-hidden="true" role="img">
   <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
 </svg>

--- a/src/sass/_uswds-theme-custom-styles.scss
+++ b/src/sass/_uswds-theme-custom-styles.scss
@@ -97,3 +97,148 @@ i.e.
     max-width: 50%;
   }
 }
+
+// Buttons
+.usa-button {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.usa-button:focus,
+.usa-button.usa-focus {
+  outline-color: color($theme-color-primary-vivid);
+}
+
+//Primary Buttons (dark)
+.usa-button.primary-button-dark:not(:disabled) {
+  color: color($theme-text-color);
+  background-color: color($theme-color-base-lightest);
+}
+
+.usa-button.primary-button-dark.usa-button--hover:not(:disabled),
+.usa-button.primary-button-dark:hover:not(:disabled) {
+  color: color($theme-text-color);
+  background-color: color($theme-color-base-lighter);
+}
+
+.usa-button.primary-button-dark.usa-button--active:not(:disabled),
+.usa-button.primary-button-dark:active:not(:disabled) {
+  color: color($theme-text-color);
+  background-color: color($theme-color-base-light);
+}
+
+//Primary Buttons (danger)
+.usa-button--secondary {
+  background-color: color($theme-color-error);
+}
+
+.usa-button--secondary.usa-button--hover,
+.usa-button--secondary:hover {
+  background-color: color($theme-color-error-dark);
+}
+
+.usa-button--secondary.usa-button--active,
+.usa-button--secondary:active {
+  background-color: color($theme-color-error-darker);
+}
+
+// Secondary buttons (light)
+.usa-button--outline {
+  color: color($theme-color-primary-dark);
+  box-shadow: inset 0 0 0 2px color($theme-color-primary-dark);
+}
+
+.usa-button--outline.usa-button--hover,
+.usa-button--outline:hover {
+  color: color($theme-color-primary-darker);
+  box-shadow: inset 0 0 0 2px color($theme-color-primary-darker);
+}
+
+.usa-button--outline.usa-button--active,
+.usa-button--outline:active {
+  color: color($theme-color-primary-darkest);
+  box-shadow: inset 0 0 0 2px color($theme-color-primary-darkest);
+}
+
+//Secondary Buttons (dark)
+.usa-button--outline.usa-button--inverse:not(:disabled) {
+  color: color($theme-link-reverse-active-color);
+  box-shadow: inset 0 0 0 2px color($theme-link-reverse-active-color);
+}
+
+.usa-button--outline.usa-button--inverse.usa-button--hover:not(:disabled),
+.usa-button--outline.usa-button--inverse:hover:not(:disabled) {
+  color: color($theme-color-base-lighter);
+  box-shadow: inset 0 0 0 2px color($theme-color-base-lighter);
+}
+
+.usa-button--outline.usa-button--inverse.usa-button--active:not(:disabled),
+.usa-button--outline.usa-button--inverse:active:not(:disabled) {
+  color: color($theme-color-base-light);
+  box-shadow: inset 0 0 0 2px color($theme-color-base-light);
+}
+
+// Secondary Buttons (danger)
+.usa-button--outline.outline-danger:not(:disabled) {
+  color: color($theme-color-error);
+  box-shadow: inset 0 0 0 2px color($theme-color-error);
+}
+
+.usa-button--hover.outline-danger:not(:disabled),
+.usa-button--outline.outline-danger:hover:not(:disabled) {
+  color: color($theme-color-error-dark);
+  box-shadow: inset 0 0 0 2px color($theme-color-error-dark);
+}
+
+.usa-button--active.outline-danger:not(:disabled),
+.usa-button--outline.outline-danger:active:not(:disabled) {
+  color: color($theme-color-error-darker);
+  box-shadow: inset 0 0 0 2px color($theme-color-error-darker);
+}
+
+// Unstyled buttons (light)
+.usa-button--unstyled {
+  border-radius: 0.25rem;
+  padding: 0.25rem;
+  font-weight: 700;
+}
+.usa-button--unstyled.usa-button--hover,
+.usa-button--unstyled:hover {
+  color: color($theme-color-primary-darker);
+}
+
+.usa-button--unstyled.usa-button--active,
+.usa-button--unstyled:active {
+  color: color($theme-color-primary-darkest);
+}
+
+//Unstyled Buttons (dark)
+.usa-button--unstyled.unstyled-button-dark {
+  color: color($theme-text-reverse-color);
+}
+
+.usa-button--unstyled.unstyled-button-dark.usa-button--hover,
+.usa-button--unstyled.unstyled-button-dark:hover {
+  color: color($theme-color-base-lighter);
+}
+
+.usa-button--unstyled.unstyled-button-dark.usa-button--active,
+.usa-button--unstyled.unstyled-button-dark:active {
+  color: color($theme-color-base-light);
+}
+
+//Unstyled Buttons (danger)
+.usa-button--unstyled.unstyled-button-danger:not(:disabled) {
+  color: color($theme-color-error);
+}
+
+.usa-button--hover.unstyled-button-danger:not(:disabled),
+.usa-button--unstyled.unstyled-button-danger:hover:not(:disabled) {
+  color: color($theme-color-error-dark);
+}
+
+.usa-button--active.unstyled-button-danger:not(:disabled),
+.usa-button--unstyled.unstyled-button-danger:active:not(:disabled) {
+  color: color($theme-color-error-darker);
+}
+

--- a/src/sass/_uswds-theme-custom-styles.scss
+++ b/src/sass/_uswds-theme-custom-styles.scss
@@ -118,7 +118,7 @@ i.e.
   outline-color: color($theme-color-primary-vivid);
 }
 
-//Primary Buttons (dark)
+// Primary Buttons (dark)
 .usa-button.primary-button-dark:not(:disabled) {
   color: color($theme-text-color);
   background-color: color($theme-color-base-lightest);
@@ -136,7 +136,7 @@ i.e.
   background-color: color($theme-color-base-light);
 }
 
-//Primary Buttons (danger)
+// Primary Buttons (danger)
 .usa-button--secondary {
   background-color: color($theme-color-error);
 }
@@ -169,7 +169,7 @@ i.e.
   box-shadow: inset 0 0 0 2px color($theme-color-primary-darkest);
 }
 
-//Secondary Buttons (dark)
+// Secondary Buttons (dark)
 .usa-button--outline.usa-button--inverse:not(:disabled) {
   color: color($theme-link-reverse-active-color);
   box-shadow: inset 0 0 0 2px color($theme-link-reverse-active-color);
@@ -222,7 +222,7 @@ i.e.
   color: color($theme-color-primary-darkest);
 }
 
-//Unstyled Buttons (dark)
+// Unstyled Buttons (dark)
 .usa-button--unstyled.unstyled-button-dark {
   color: color($theme-text-reverse-color);
 }
@@ -237,7 +237,7 @@ i.e.
   color: color($theme-color-base-light);
 }
 
-//Unstyled Buttons (danger)
+// Unstyled Buttons (danger)
 .usa-button--unstyled.unstyled-button-danger:not(:disabled) {
   color: color($theme-color-error);
 }

--- a/src/sass/_uswds-theme-custom-styles.scss
+++ b/src/sass/_uswds-theme-custom-styles.scss
@@ -100,18 +100,18 @@ i.e.
 
 // Buttons
 .usa-button {
-  height:units(6);
+  height: units(6);
   padding: units(2) units(2.5);
   &.button-icon {
-    padding-top:units(1.5);
-    padding-bottom:0.875rem;
+    padding-top: units(1.5);
+    padding-bottom: 0.875rem;
   }
 }
 
 .button-icon svg {
-    vertical-align: sub;
-    margin-bottom: -2px;
-  }
+  vertical-align: sub;
+  margin-bottom: -2px;
+}
 
 .usa-button:focus,
 .usa-button.usa-focus {
@@ -207,10 +207,10 @@ i.e.
 
 // Unstyled buttons (light)
 .usa-button--unstyled {
-  border-radius: units(.5);
-  padding: units(.5);
+  border-radius: units(0.5);
+  padding: units(0.5);
   font-weight: $theme-font-weight-bold;
-  height:auto;
+  height: auto;
 }
 .usa-button--unstyled.usa-button--hover,
 .usa-button--unstyled:hover {
@@ -251,4 +251,3 @@ i.e.
 .usa-button--unstyled.unstyled-button-danger:active:not(:disabled) {
   color: color($theme-color-error-darker);
 }
-

--- a/src/sass/_uswds-theme-custom-styles.scss
+++ b/src/sass/_uswds-theme-custom-styles.scss
@@ -100,9 +100,18 @@ i.e.
 
 // Buttons
 .usa-button {
-  padding-top: 1rem;
-  padding-bottom: 1rem;
+  height:units(6);
+  padding: units(2) units(2.5);
+  &.button-icon {
+    padding-top:units(1.5);
+    padding-bottom:0.875rem;
+  }
 }
+
+.button-icon svg {
+    vertical-align: sub;
+    margin-bottom: -2px;
+  }
 
 .usa-button:focus,
 .usa-button.usa-focus {
@@ -198,9 +207,10 @@ i.e.
 
 // Unstyled buttons (light)
 .usa-button--unstyled {
-  border-radius: 0.25rem;
-  padding: 0.25rem;
-  font-weight: 700;
+  border-radius: units(.5);
+  padding: units(.5);
+  font-weight: $theme-font-weight-bold;
+  height:auto;
 }
 .usa-button--unstyled.usa-button--hover,
 .usa-button--unstyled:hover {


### PR DESCRIPTION
Updating the style to follow the [button design](https://www.figma.com/design/z8CI77qQvbffkCslHANatK/NJ-Web-Design-System?node-id=2-4297&node-type=canvas&t=15xZteC0NttNzyVm-0). 

There are three main types (primary/secondary/tertiary) that have 3 versions (light mode, dark mode, danger), so a total of 9 options. In addition, the buttons have an option to include an icon (with it either leading, trailing, or only having an icon without text). 

Additionally, I have added the icon to the fractal library as well to show the sizes represented in the [design](https://www.figma.com/design/z8CI77qQvbffkCslHANatK/NJ-Web-Design-System?node-id=2-15930&node-type=canvas&t=E8CKs20hqhtSxnku-0)

**To run:**
Run `npm run build-docs` to general a component gallery for reviewing the style guide 
Run `npm start` to build the component library, launch a web server to host it, and live reload on development changes.

Example button component in library 
![Screenshot 2024-09-13 at 10 08 19 AM](https://github.com/user-attachments/assets/61ddce03-309d-4eef-87f5-1c0d13a692c5)

Buttons
![Screenshot 2024-09-12 at 8 59 32 PM](https://github.com/user-attachments/assets/df5d2eef-0e91-44b2-88f2-c73706282769)
![Screenshot 2024-09-12 at 8 53 33 PM](https://github.com/user-attachments/assets/a68cc637-be14-42b8-ab9f-e5c52982f20e)
![Screenshot 2024-09-12 at 8 53 36 PM](https://github.com/user-attachments/assets/cd051ce6-90a3-478b-800a-6c386a59e2dc)
![Screenshot 2024-09-12 at 8 58 02 PM](https://github.com/user-attachments/assets/b580cc5d-f23e-4635-a566-84bb7d033b57)
![Screenshot 2024-09-12 at 8 58 06 PM](https://github.com/user-attachments/assets/a1cc9ef9-764c-4047-a747-2f4e0dc7861b)
![Screenshot 2024-09-12 at 8 58 10 PM](https://github.com/user-attachments/assets/100d88ae-f52d-4f21-8ebc-660e39fcc70d)
![Screenshot 2024-09-12 at 8 58 17 PM](https://github.com/user-attachments/assets/25552a94-6c15-436d-b578-1cc32b34c505)
![Screenshot 2024-09-12 at 8 58 24 PM](https://github.com/user-attachments/assets/dc6405d4-501d-48f9-80d2-77d66694dfd1)
![Screenshot 2024-09-12 at 8 58 28 PM](https://github.com/user-attachments/assets/125ec694-6105-4a22-b698-f32e3658ac90)

Also added icon into the library with the approved sizes:
![Screenshot 2024-09-13 at 10 10 43 AM](https://github.com/user-attachments/assets/bf6fe986-55cb-4f9b-af9c-72896f16a680)


