### PR TITLE
Updates to default icon size

### DIFF
--- a/src/components/icon/icon.njk
+++ b/src/components/icon/icon.njk
@@ -1,3 +1,7 @@
+<svg class="usa-icon" focusable="false" aria-hidden="true" role="img">
+  <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
+</svg>
+
 <svg class="usa-icon usa-icon--size-3" focusable="false" aria-hidden="true" role="img">
   <use xlink:href="{{ uswds.path }}/img/sprite.svg#accessibility_new"></use>
 </svg>

--- a/src/sass/_uswds-theme-custom-styles.scss
+++ b/src/sass/_uswds-theme-custom-styles.scss
@@ -251,3 +251,16 @@ i.e.
 .usa-button--unstyled.unstyled-button-danger:active:not(:disabled) {
   color: color($theme-color-error-darker);
 }
+
+.usa-icon:not(
+    .usa-icon--size-3,
+    .usa-icon--size-4,
+    .usa-icon--size-5,
+    .usa-icon--size-6,
+    .usa-icon--size-7,
+    .usa-icon--size-8,
+    .usa-icon--size-9
+  ) {
+  width: 20px;
+  height: 20px;
+}


### PR DESCRIPTION
Updating the USWDS usa-icon class to have a default of 20*20 size (will not override the additional sizes)