### PR TITLE
Implement custom radio tile styling

### DIFF
--- a/src/components/07-form/controls/radio-buttons.config.yml
+++ b/src/components/07-form/controls/radio-buttons.config.yml
@@ -1,0 +1,14 @@
+label: Radio Buttons
+status: ready
+
+variants:
+  - name: default
+    label: Default
+    context:
+      label: Default Radio Buttons
+      classes: ""
+  - name: tile
+    label: Tile
+    context:
+      label: Tile Radio Buttons
+      classes: "usa-radio__input--tile"

--- a/src/components/07-form/controls/radio-buttons.njk
+++ b/src/components/07-form/controls/radio-buttons.njk
@@ -1,21 +1,22 @@
+{%- set inputClasses = 'usa-radio__input ' + classes -%}
 <form class="usa-form">
   <fieldset class="usa-fieldset">
     <legend class="usa-legend usa-legend">Select one historical figure</legend>
     <div class="usa-radio">
-      <input class="usa-radio__input" id="historical-truth" type="radio" name="historical-figures" value="sojourner-truth">
-      <label class="usa-radio__label" for="historical-truth">Sojourner Truth</label>
-    </div>
-    <div class="usa-radio">
-      <input class="usa-radio__input" id="historical-douglass" type="radio" name="historical-figures" value="frederick-douglass">
-      <label class="usa-radio__label" for="historical-douglass">Frederick Douglass</label>
-    </div>
-    <div class="usa-radio">
-      <input class="usa-radio__input" id="historical-washington" type="radio" name="historical-figures" value="booker-t-washington">
-      <label class="usa-radio__label" for="historical-washington">Booker T. Washington</label>
-    </div>
-    <div class="usa-radio">
-      <input class="usa-radio__input" id="historical-carver" type="radio" name="historical-figures" value="george-washington-carver" disabled>
-      <label class="usa-radio__label" for="historical-carver">George Washington Carver</label>
-    </div>
-  </fieldset>
-</form>
+      <input class="{{ inputClasses }}" id="historical-truth" type="radio" name="historical-figures" value="sojourner-truth">
+        <label class="usa-radio__label" for="historical-truth">Sojourner Truth</label>
+      </div>
+      <div class="usa-radio">
+        <input class="{{ inputClasses }}" id="historical-douglass" type="radio" name="historical-figures" value="frederick-douglass">
+          <label class="usa-radio__label" for="historical-douglass">Frederick Douglass</label>
+        </div>
+        <div class="usa-radio">
+          <input class="{{ inputClasses }}" id="historical-washington" type="radio" name="historical-figures" value="booker-t-washington">
+            <label class="usa-radio__label" for="historical-washington">Booker T. Washington</label>
+          </div>
+          <div class="usa-radio">
+            <input class="{{ inputClasses }}" id="historical-carver" type="radio" name="historical-figures" value="george-washington-carver" disabled>
+              <label class="usa-radio__label" for="historical-carver">George Washington Carver</label>
+            </div>
+          </fieldset>
+        </form>

--- a/src/sass/_uswds-theme-custom-styles.scss
+++ b/src/sass/_uswds-theme-custom-styles.scss
@@ -264,3 +264,8 @@ i.e.
   width: 20px;
   height: 20px;
 }
+
+// Radio Buttons (tile)
+.usa-radio__input--tile:checked+[class*=__label] {
+  background-color: color($theme-color-primary-lighter);
+}

--- a/src/sass/_uswds-theme.scss
+++ b/src/sass/_uswds-theme.scss
@@ -107,7 +107,8 @@
   // Layout Grid
   $theme-layout-grid-use-important: false,
   // Focus Styles
-  $theme-focus-color: "primary",
+  $theme-focus-color: "primary-vivid",
+
   // Site
   $theme-grid-container-max-width: "desktop",
   // Global Styles


### PR DESCRIPTION
* Changes the background color on a selected tile radio button to `primary-lighter` to match the [NJWDS Figma](https://www.figma.com/design/z8CI77qQvbffkCslHANatK/NJ-Web-Design-System?node-id=2-19547&node-type=canvas&t=BzboOE1yuhbqZvki-0)
* Also adds the tile variant to the Fractal docs
* Changes the focus ring color to `primary-vivid`

**New Tile Styling**
<img width="647" alt="Screenshot of Tile variant in Fractal docs" src="https://github.com/user-attachments/assets/84152e1b-a35d-41d1-859e-71c055eff0f7">

**Original USWDS Tile Styling**
<img width="365" alt="Screenshot of original USWDS tile styling" src="https://github.com/user-attachments/assets/8a5d8f7b-8a77-40d4-beb7-bfd3dccf1b89">
