### PR TITLE
Removes white ring from checked radio tile styling

### DIFF
--- a/src/sass/_uswds-theme-custom-styles.scss
+++ b/src/sass/_uswds-theme-custom-styles.scss
@@ -282,4 +282,6 @@ i.e.
 .usa-radio__input--tile+[class*=__label] {
   border-color: color($theme-color-base-light);
 }
-
+.usa-radio__input.usa-radio__input--tile:checked + [class*=__label]::before{
+  box-shadow: 0 0 0 2px #005ea2,inset 0 0 0 2px #cfe8ff;
+}


### PR DESCRIPTION
Radio tile styling has white ring around the circle, this has now been removed. It does not impact the radio button without tile 

Updated tile:
![Screenshot 2024-10-31 at 12 03 27 PM](https://github.com/user-attachments/assets/5747374d-8624-4b5a-8a7e-f39701cc7d48)
![Screenshot 2024-10-31 at 12 03 32 PM](https://github.com/user-attachments/assets/f5579fd4-51f6-427f-bb20-fc6d52d8bc05)

Default Radio item remains unchanged
![Screenshot 2024-10-31 at 12 03 38 PM](https://github.com/user-attachments/assets/6f65f108-c358-4a96-bbda-93d6cff5acf6)
