### PR TITLE
Update custom classnames with  prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,15 @@ The NJWDS package also includes pre-compiled files in the `src/` directory. Spec
 
 - Clone this repository
 - Run `npm install`
-- [Optional] Run `npm run import-components` to important new USWDS components. This only needs to be done if new upstream components are developed
+- [Optional] Run `npm run import-components` to import new USWDS components. This only needs to be done if new upstream components are developed. This imports the USWDS, pulls in the NJ-specific components and styles, and saves them in a `dist` directory. Note: This option may no longer work in the workflow, use caution when trying it out to check for regressions.
 
-This imports the USWDS, pulls in the NJ-specific components and styles, and saves them in a `dist` directory.
+## Build the design system assets
+
+- Run `npm run build-uswds` to build the assets into the `dist/` directory
 
 ### Build the component library
 
-- Run `npm run build-docs` to general a [Fractal]() component gallery for reviewing the style guide
+- Run `npm run build-docs` to build the [Fractal]() component gallery for reviewing the component documentation
 
 ### View component library locally or development
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The NJWDS package also includes pre-compiled files in the `src/` directory. Spec
 
 - Clone this repository
 - Run `npm install`
-- [Optional] Run `npm run import-components` to import new USWDS components. This only needs to be done if new upstream components are developed. This imports the USWDS, pulls in the NJ-specific components and styles, and saves them in a `dist` directory. Note: This option may no longer work in the workflow, use caution when trying it out to check for regressions.
+- [Optional] Run `npm run import-components` to import new USWDS components. This only needs to be done if new upstream components are developed. This imports the USWDS, pulls in the NJ-specific components and styles, and saves them in a `dist` directory. Note: This option may no longer work, if trying it out, use caution and check for regressions.
 
 ## Build the design system assets
 
@@ -43,7 +43,7 @@ The NJWDS package also includes pre-compiled files in the `src/` directory. Spec
 
 ### Build the component library
 
-- Run `npm run build-docs` to build the [Fractal]() component gallery for reviewing the component documentation
+- Run `npm run build-docs` to build the [Fractal](https://fractal.build/) component gallery for reviewing the component documentation
 
 ### View component library locally or development
 
@@ -53,9 +53,9 @@ The NJWDS package also includes pre-compiled files in the `src/` directory. Spec
 
 - Run `npm run deploy`
 
-This builds USWDS styles, builds the Fractal docs, and then deploys them to the gh-pages branch.
+This builds USWDS styles, builds the Fractal docs, and then deploys them to the `gh-pages` branch.
 
-Note: do not push directly to the gh-pages branch.
+Note: Do not push directly to the `gh-pages` branch. This is done automatically when committing to `main`.
 
 ## Releasing a new version to NPM
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# NJ Web Design Standards
+# New Jersey Web Design System (NJWDS)
 
-The NJ Web Design Standards are an extension of the [US Web Design Standards](https://github.com/uswds/uswds/) with a specific theme and components for State of New Jersey digital properties and services.
+The NJ Web Design System is an extension of the [US Web Design System](https://github.com/uswds/uswds/) with a specific theme and components for State of New Jersey digital properties and services.
 
 ## How to install and use the NJWDS
 

--- a/src/components/02-buttons/buttons.config.yml
+++ b/src/components/02-buttons/buttons.config.yml
@@ -6,7 +6,7 @@ variants:
     context:
       category: primary
       label: Primary Buttons (Dark)
-      classes: "nj-primary-button-dark"
+      classes: "nj-button--primary-dark"
 
   - name: Primary (Danger)
     context:
@@ -30,7 +30,7 @@ variants:
     context:
       category: secondary
       label: Secondary Buttons (Danger)
-      classes: "usa-button--outline nj-outline-danger"
+      classes: "usa-button--outline nj-button--outline-danger"
 
   - name: Tertiary (Light)
     context:
@@ -42,10 +42,10 @@ variants:
     context:
       category: Tertiary/Link
       label: Tertiary/Link Dark Buttons
-      classes: "usa-button--unstyled nj-unstyled-button-dark"
+      classes: "usa-button--unstyled nj-button--unstyled-dark"
 
   - name: Tertiary (Danger)
     context:
       category: Tertiary/Danger
       label: Tertiary/Link Danger Buttons
-      classes: "usa-button--unstyled nj-unstyled-button-danger"
+      classes: "usa-button--unstyled nj-button--unstyled-danger"

--- a/src/components/02-buttons/buttons.config.yml
+++ b/src/components/02-buttons/buttons.config.yml
@@ -2,12 +2,11 @@ label: Buttons
 status: ready
 default: Primary (Light)
 variants:
-
   - name: Primary (Dark)
     context:
       category: primary
       label: Primary Buttons (Dark)
-      classes: "primary-button-dark"
+      classes: "nj-primary-button-dark"
 
   - name: Primary (Danger)
     context:
@@ -31,7 +30,7 @@ variants:
     context:
       category: secondary
       label: Secondary Buttons (Danger)
-      classes: "usa-button--outline outline-danger"
+      classes: "usa-button--outline nj-outline-danger"
 
   - name: Tertiary (Light)
     context:
@@ -43,10 +42,10 @@ variants:
     context:
       category: Tertiary/Link
       label: Tertiary/Link Dark Buttons
-      classes: "usa-button--unstyled unstyled-button-dark"
+      classes: "usa-button--unstyled nj-unstyled-button-dark"
 
-  - name: Tertiary (Danger) 
+  - name: Tertiary (Danger)
     context:
       category: Tertiary/Danger
       label: Tertiary/Link Danger Buttons
-      classes: "usa-button--unstyled unstyled-button-danger"
+      classes: "usa-button--unstyled nj-unstyled-button-danger"

--- a/src/sass/_uswds-theme-custom-styles.scss
+++ b/src/sass/_uswds-theme-custom-styles.scss
@@ -119,19 +119,19 @@ i.e.
 }
 
 // Primary Buttons (dark)
-.usa-button.nj-primary-button-dark:not(:disabled) {
+.usa-button.nj-button--primary-dark:not(:disabled) {
   color: color($theme-text-color);
   background-color: color($theme-color-base-lightest);
 }
 
-.usa-button.nj-primary-button-dark.usa-button--hover:not(:disabled),
-.usa-button.nj-primary-button-dark:hover:not(:disabled) {
+.usa-button.nj-button--primary-dark.usa-button--hover:not(:disabled),
+.usa-button.nj-button--primary-dark:hover:not(:disabled) {
   color: color($theme-text-color);
   background-color: color($theme-color-base-lighter);
 }
 
-.usa-button.nj-primary-button-dark.usa-button--active:not(:disabled),
-.usa-button.nj-primary-button-dark:active:not(:disabled) {
+.usa-button.nj-button--primary-dark.usa-button--active:not(:disabled),
+.usa-button.nj-button--primary-dark:active:not(:disabled) {
   color: color($theme-text-color);
   background-color: color($theme-color-base-light);
 }
@@ -188,19 +188,19 @@ i.e.
 }
 
 // Secondary Buttons (danger)
-.usa-button--outline.nj-outline-danger:not(:disabled) {
+.usa-button--outline.nj-button--outline-danger:not(:disabled) {
   color: color($theme-color-error);
   box-shadow: inset 0 0 0 2px color($theme-color-error);
 }
 
-.usa-button--hover.nj-outline-danger:not(:disabled),
-.usa-button--outline.nj-outline-danger:hover:not(:disabled) {
+.usa-button--hover.nj-button--outline-danger:not(:disabled),
+.usa-button--outline.nj-button--outline-danger:hover:not(:disabled) {
   color: color($theme-color-error-dark);
   box-shadow: inset 0 0 0 2px color($theme-color-error-dark);
 }
 
-.usa-button--active.nj-outline-danger:not(:disabled),
-.usa-button--outline.nj-outline-danger:active:not(:disabled) {
+.usa-button--active.nj-button--outline-danger:not(:disabled),
+.usa-button--outline.nj-button--outline-danger:active:not(:disabled) {
   color: color($theme-color-error-darker);
   box-shadow: inset 0 0 0 2px color($theme-color-error-darker);
 }
@@ -223,32 +223,32 @@ i.e.
 }
 
 // Unstyled Buttons (dark)
-.usa-button--unstyled.nj-unstyled-button-dark {
+.usa-button--unstyled.nj-button--unstyled-dark {
   color: color($theme-text-reverse-color);
 }
 
-.usa-button--unstyled.nj-unstyled-button-dark.usa-button--hover,
-.usa-button--unstyled.nj-unstyled-button-dark:hover {
+.usa-button--unstyled.nj-button--unstyled-dark.usa-button--hover,
+.usa-button--unstyled.nj-button--unstyled-dark:hover {
   color: color($theme-color-base-lighter);
 }
 
-.usa-button--unstyled.nj-unstyled-button-dark.usa-button--active,
-.usa-button--unstyled.nj-unstyled-button-dark:active {
+.usa-button--unstyled.nj-button--unstyled-dark.usa-button--active,
+.usa-button--unstyled.nj-button--unstyled-dark:active {
   color: color($theme-color-base-light);
 }
 
 // Unstyled Buttons (danger)
-.usa-button--unstyled.nj-unstyled-button-danger:not(:disabled) {
+.usa-button--unstyled.nj-button--unstyled-danger:not(:disabled) {
   color: color($theme-color-error);
 }
 
-.usa-button--hover.nj-unstyled-button-danger:not(:disabled),
-.usa-button--unstyled.nj-unstyled-button-danger:hover:not(:disabled) {
+.usa-button--hover.nj-button--unstyled-danger:not(:disabled),
+.usa-button--unstyled.nj-button--unstyled-danger:hover:not(:disabled) {
   color: color($theme-color-error-dark);
 }
 
-.usa-button--active.nj-unstyled-button-danger:not(:disabled),
-.usa-button--unstyled.nj-unstyled-button-danger:active:not(:disabled) {
+.usa-button--active.nj-button--unstyled-danger:not(:disabled),
+.usa-button--unstyled.nj-button--unstyled-danger:active:not(:disabled) {
   color: color($theme-color-error-darker);
 }
 

--- a/src/sass/_uswds-theme-custom-styles.scss
+++ b/src/sass/_uswds-theme-custom-styles.scss
@@ -119,19 +119,19 @@ i.e.
 }
 
 // Primary Buttons (dark)
-.usa-button.primary-button-dark:not(:disabled) {
+.usa-button.nj-primary-button-dark:not(:disabled) {
   color: color($theme-text-color);
   background-color: color($theme-color-base-lightest);
 }
 
-.usa-button.primary-button-dark.usa-button--hover:not(:disabled),
-.usa-button.primary-button-dark:hover:not(:disabled) {
+.usa-button.nj-primary-button-dark.usa-button--hover:not(:disabled),
+.usa-button.nj-primary-button-dark:hover:not(:disabled) {
   color: color($theme-text-color);
   background-color: color($theme-color-base-lighter);
 }
 
-.usa-button.primary-button-dark.usa-button--active:not(:disabled),
-.usa-button.primary-button-dark:active:not(:disabled) {
+.usa-button.nj-primary-button-dark.usa-button--active:not(:disabled),
+.usa-button.nj-primary-button-dark:active:not(:disabled) {
   color: color($theme-text-color);
   background-color: color($theme-color-base-light);
 }
@@ -188,19 +188,19 @@ i.e.
 }
 
 // Secondary Buttons (danger)
-.usa-button--outline.outline-danger:not(:disabled) {
+.usa-button--outline.nj-outline-danger:not(:disabled) {
   color: color($theme-color-error);
   box-shadow: inset 0 0 0 2px color($theme-color-error);
 }
 
-.usa-button--hover.outline-danger:not(:disabled),
-.usa-button--outline.outline-danger:hover:not(:disabled) {
+.usa-button--hover.nj-outline-danger:not(:disabled),
+.usa-button--outline.nj-outline-danger:hover:not(:disabled) {
   color: color($theme-color-error-dark);
   box-shadow: inset 0 0 0 2px color($theme-color-error-dark);
 }
 
-.usa-button--active.outline-danger:not(:disabled),
-.usa-button--outline.outline-danger:active:not(:disabled) {
+.usa-button--active.nj-outline-danger:not(:disabled),
+.usa-button--outline.nj-outline-danger:active:not(:disabled) {
   color: color($theme-color-error-darker);
   box-shadow: inset 0 0 0 2px color($theme-color-error-darker);
 }
@@ -223,32 +223,32 @@ i.e.
 }
 
 // Unstyled Buttons (dark)
-.usa-button--unstyled.unstyled-button-dark {
+.usa-button--unstyled.nj-unstyled-button-dark {
   color: color($theme-text-reverse-color);
 }
 
-.usa-button--unstyled.unstyled-button-dark.usa-button--hover,
-.usa-button--unstyled.unstyled-button-dark:hover {
+.usa-button--unstyled.nj-unstyled-button-dark.usa-button--hover,
+.usa-button--unstyled.nj-unstyled-button-dark:hover {
   color: color($theme-color-base-lighter);
 }
 
-.usa-button--unstyled.unstyled-button-dark.usa-button--active,
-.usa-button--unstyled.unstyled-button-dark:active {
+.usa-button--unstyled.nj-unstyled-button-dark.usa-button--active,
+.usa-button--unstyled.nj-unstyled-button-dark:active {
   color: color($theme-color-base-light);
 }
 
 // Unstyled Buttons (danger)
-.usa-button--unstyled.unstyled-button-danger:not(:disabled) {
+.usa-button--unstyled.nj-unstyled-button-danger:not(:disabled) {
   color: color($theme-color-error);
 }
 
-.usa-button--hover.unstyled-button-danger:not(:disabled),
-.usa-button--unstyled.unstyled-button-danger:hover:not(:disabled) {
+.usa-button--hover.nj-unstyled-button-danger:not(:disabled),
+.usa-button--unstyled.nj-unstyled-button-danger:hover:not(:disabled) {
   color: color($theme-color-error-dark);
 }
 
-.usa-button--active.unstyled-button-danger:not(:disabled),
-.usa-button--unstyled.unstyled-button-danger:active:not(:disabled) {
+.usa-button--active.nj-unstyled-button-danger:not(:disabled),
+.usa-button--unstyled.nj-unstyled-button-danger:active:not(:disabled) {
   color: color($theme-color-error-darker);
 }
 
@@ -275,13 +275,13 @@ i.e.
 }
 
 // Radio Buttons (tile)
-.usa-radio__input--tile:checked+[class*=__label] {
+.usa-radio__input--tile:checked + [class*="__label"] {
   background-color: color($theme-color-primary-lighter);
 }
 
-.usa-radio__input--tile+[class*=__label] {
+.usa-radio__input--tile + [class*="__label"] {
   border-color: color($theme-color-base-light);
 }
-.usa-radio__input.usa-radio__input--tile:checked + [class*=__label]::before{
-  box-shadow: 0 0 0 2px #005ea2,inset 0 0 0 2px #cfe8ff;
+.usa-radio__input.usa-radio__input--tile:checked + [class*="__label"]::before {
+  box-shadow: 0 0 0 2px #005ea2, inset 0 0 0 2px #cfe8ff;
 }


### PR DESCRIPTION
## Overview
- We added in custom button classes to enable styling of NJWDS buttons in ways that USWDS did not support
- To make this clearer that it is NJ-specific, I've added an `nj-` prefix to classnames

## Test plan
1. Ran `npm run build-uswds` to build the latest stylesheet
2. Ran `npm run build-docs` to build updated docs (with new classnames used)
3. Ran `npm run start` to run the docs locally
4. Compare local docs with production docs (https://newjersey.github.io/njwds/index.html) to see there's no regressions 