### PR TITLE
Add start tag for release notes to draft release action

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -54,10 +54,18 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ needs.update-version.outputs.release_sha }}
+      - name: Get latest release
+        id: latest_release
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repos/newjersey/njwds/releases/latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: |
           gh release create ${{ needs.update-version.outputs.new_version }} \
           --draft \
           --generate-notes \
+          --notes-start-tag ${{ steps.latest_release.outputs.data }} \
           --target ${{ needs.update-version.outputs.release_sha }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pull in the latest published release version and use this as the start tag when generating notes for a new draft release