### PR TITLE
Remove combobox's disabled and placeholder variants

### DIFF
--- a/src/components/07-form/controls/combo-box.config.yml
+++ b/src/components/07-form/controls/combo-box.config.yml
@@ -15,21 +15,13 @@ variants:
     context:
       comboBox:
         defaultValue: "blackberry"
-
-  - name: disabled
-    label: Disabled
-    context:
-      comboBox:
-        disabled: true
-
-  - name: placeholder
-    label: Placeholder
-    context:
-      comboBox:
-        placeholder: "Select one..."
+        label: "Select a fruit"
+        name: "fruit"
 
   - name: required
     label: Required
     context:
       comboBox:
+        label: "Select a fruit"
+        name: "fruit"
         required: true


### PR DESCRIPTION
This PR removes the combobox component's disabled and placeholder variants to match with the [combobox GitBook documentation](https://app.gitbook.com/o/sZfyNxWUXa0Xqt60FztK/s/yr4X3QRKVxYz7UzN3SjO/combobox).

Also adds the `label` and `name` properties to the `combo-box.config.yml` to ensure the docs use correct semantic HTML. 