### PR TITLE
Update npm publish workflow to use OIDC

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,17 +4,24 @@ on:
     types:
       - published
 
+permissions:
+  id-token: write  # Required for OIDC (https://docs.npmjs.com/trusted-publishers)
+  contents: read
+
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
       - name: Setup npm to publish to npmjs
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
+      
+      # Ensure npm 11.5.1 or later is installed
+      - name: Update npm
+        run: npm install -g npm@latest
       - run: npm ci
       - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
We got a notice from npm that we need to migrate off tokens into OIDC trusted publishers. This is lifting action code from the documentation: https://docs.npmjs.com/trusted-publishers#github-actions-configuration

> Security Update: npm classic token creation is now disabled. Existing classic tokens will be revoked on December 9, 2025. Migrate to trusted publishing or granular access tokens to avoid disruption. [Learn more](https://gh.io/npm-token-changes)

Trusted published setup:

<img width="802" height="247" alt="Screenshot 2025-11-20 at 12 29 01 PM" src="https://github.com/user-attachments/assets/5b1fec11-20a6-4417-b6c5-e3a59a102f57" />
