### PR TITLE
Add link in banner to page about the Governor

### DIFF
--- a/src/components/banner/banner.njk
+++ b/src/components/banner/banner.njk
@@ -9,7 +9,14 @@
           <a href="https://nj.gov">{{ banner.stateOfNjText }}</a>
         </div>
         <ul class="grid-col-auto display-flex flex-align-center">
-          <li>{{ banner.governorName }} &bull; {{ banner.ltGovernorName }}</li>
+          <li>
+            <a
+              href="https://nj.gov/governor/" 
+              target="_blank"
+            >
+              {{ banner.governorName }} &bull; {{ banner.ltGovernorName }}
+            </a>
+          </li>
           <li class="grid-col-auto">
             <a 
               class="display-flex flex-align-center"


### PR DESCRIPTION
The banner on https://nj.gov/ includes the text "Governor Phil Murphy • Lt. Governor Tahesha Way" that links to https://nj.gov/governor/. Previously, this link was not reflected in the NJWDS banner component.

This commit updates the banner Governor text to link to https://nj.gov/governor/. It opens in a new tab to mirror the behavior of the https://nj.gov/subscribe/ link.

Not super sure if opening in a new tab is the behavior we want.

<img width="1466" height="626" alt="image" src="https://github.com/user-attachments/assets/c3c1ad68-8311-4d94-b100-c3915b18bf3c" />
