### PR TITLE
fix: prevent footer overflow on narrow screens

### DIFF
--- a/src/stories/components/Footer/Footer.ts
+++ b/src/stories/components/Footer/Footer.ts
@@ -25,16 +25,18 @@ export const Footer = ({ variant }: FooterProps) => {
   if (variant === "Default") {
     primarySection = html`
       <div class="usa-footer__primary-section">
-        <nav class="usa-footer__nav" aria-label="Footer navigation">
-          <ul class="grid-row grid-gap">
-            <li class="mobile-lg:grid-col-4 desktop:grid-col-auto usa-footer__primary-content">
-              <a class="usa-footer__primary-link" href="#!">Primary link</a>
-            </li>
-            <li class="mobile-lg:grid-col-4 desktop:grid-col-auto usa-footer__primary-content">
-              <a class="usa-footer__primary-link" href="#!">Primary link</a>
-            </li>
-          </ul>
-        </nav>
+        <div class="grid-container">
+          <nav class="usa-footer__nav" aria-label="Footer navigation">
+            <ul class="grid-row grid-gap">
+              <li class="mobile-lg:grid-col-4 desktop:grid-col-auto usa-footer__primary-content">
+                <a class="usa-footer__primary-link" href="#!">Primary link</a>
+              </li>
+              <li class="mobile-lg:grid-col-4 desktop:grid-col-auto usa-footer__primary-content">
+                <a class="usa-footer__primary-link" href="#!">Primary link</a>
+              </li>
+            </ul>
+          </nav>
+        </div>
       </div>
     `;
   } else if (variant === "Big") {
@@ -44,7 +46,7 @@ export const Footer = ({ variant }: FooterProps) => {
           <div class="grid-row grid-gap">
             <div class="tablet:grid-col-8">
               <nav class="usa-footer__nav" aria-label="Footer navigation">
-                <div class="grid-row grid-gap-4">
+                <div class="grid-row mobile-lg:grid-gap-4">
                   <div class="mobile-lg:grid-col-6 desktop:grid-col-3">
                     <section
                       class="usa-footer__primary-content usa-footer__primary-content--collapsible"
@@ -115,7 +117,7 @@ export const Footer = ({ variant }: FooterProps) => {
         <div class="usa-footer__primary-container grid-row">
           <div class="mobile-lg:grid-col-8">
             <nav class="usa-footer__nav" aria-label="Footer navigation">
-              <ul class="grid-row grid-gap">
+              <ul class="grid-row mobile-lg:grid-gap">
                 <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
                   <a class="usa-footer__primary-link" href="#!">Primary link</a>
                 </li>
@@ -127,7 +129,7 @@ export const Footer = ({ variant }: FooterProps) => {
           </div>
           <div class="mobile-lg:grid-col-4">
             <address class="usa-footer__address">
-              <div class="grid-row grid-gap">
+              <div class="grid-row mobile-lg:grid-gap">
                 <div class="grid-col-auto mobile-lg:grid-col-12 desktop:grid-col-auto">
                   <div class="usa-footer__contact-info">
                     <a href="tel:1-800-555-5555">(800) CALL-GOVT</a>

--- a/src/tests/components/footer/accessibility/footer.accessibility.spec.ts
+++ b/src/tests/components/footer/accessibility/footer.accessibility.spec.ts
@@ -1,3 +1,5 @@
+import { expect, test } from "@playwright/test";
+import { STORYBOOK_URL } from "../../../../utils/config";
 import { runA11ySuite } from "../../../../utils/runA11ySuite";
 
 // Define all the story URLs and friendly names for reporting
@@ -20,4 +22,20 @@ runA11ySuite({
   suiteName: "Footer",
   include: ".usa-footer",
   cases: TEST_CASES,
+});
+
+test.describe("Footer responsive layout", () => {
+  for (const { name, url } of TEST_CASES) {
+    test(`${name} does not overflow a 320px viewport`, async ({ page }) => {
+      await page.setViewportSize({ width: 320, height: 800 });
+      await page.goto(`${STORYBOOK_URL}${url}`);
+
+      const dimensions = await page.locator("html").evaluate((element) => ({
+        clientWidth: element.clientWidth,
+        scrollWidth: element.scrollWidth,
+      }));
+
+      expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth);
+    });
+  }
 });


### PR DESCRIPTION
## Summary

This change fixes horizontal page overflow in all three Grove footer variants at narrow viewport widths and adds a browser-level regression test that verifies the complete footer remains within a 320 CSS-pixel viewport.

The implementation stays within Grove and USWDS layout primitives. It does not add overflow clipping, fixed widths, or component-specific CSS overrides.

## Problem

The default, big, and slim footer stories can extend beyond the viewport at 320 CSS pixels:

- the default footer's primary navigation uses a guttered `grid-row` without a surrounding `grid-container`;
- the big footer applies `grid-gap-4` before its navigation becomes a multi-column layout; and
- the slim footer applies base `grid-gap` classes to rows that remain single-column at the smallest widths.

USWDS grid gaps are implemented with negative row margins and corresponding child padding. That structure works when the guttered row is inside the expected container and when the child columns participate in the matching grid layout. At narrow widths, the current footer markup applies the negative margins without all of the balancing conditions, increasing the document's `scrollWidth` beyond its `clientWidth`.

The measured overflow was:

- **Default footer:** 8 CSS pixels before correction;
- **Big footer:** 12 CSS pixels before correction; and
- **Slim footer:** 4 CSS pixels before correction.

This is easy to miss during visual review because Grove's global styles can conceal the excess width. Hiding horizontal overflow does not correct the underlying layout: content may still be clipped, browser zoom can expose the defect, and downstream applications that do not inherit the same global rule remain affected.

## Implementation

### Default footer

The default footer's primary navigation is now wrapped in a `grid-container`:

```html
<div class="usa-footer__primary-section">
  <div class="grid-container">
    <nav class="usa-footer__nav" aria-label="Footer navigation">
      <ul class="grid-row grid-gap">
        ...
      </ul>
    </nav>
  </div>
</div>
```

The container supplies the inline padding that balances the guttered row's negative margins. This follows the USWDS grid composition model and preserves the existing link structure, breakpoints, and footer appearance.

### Big footer

The big footer navigation changes:

```text
grid-row grid-gap-4
```

to:

```text
grid-row mobile-lg:grid-gap-4
```

The footer is a single-column layout below `mobile-lg`. Deferring the larger gap until the same breakpoint where the navigation establishes its columns prevents mobile-only negative margins while preserving the intended spacing once the multi-column layout is active.

### Slim footer

The slim footer applies the same mobile-first rule to its primary navigation and contact rows:

```text
grid-row mobile-lg:grid-gap
```

At the smallest viewport sizes, these rows no longer introduce gutters before their children use the corresponding column layout. At `mobile-lg` and above, the current spacing is retained.

## Why this approach

This change corrects the grid composition rather than suppressing its visible symptom.

Alternatives such as `overflow-x: hidden`, fixed widths, arbitrary padding, or footer-specific negative-margin overrides were not used because they would:

- hide clipped content instead of restoring reflow;
- detach the footer from Grove and USWDS layout behavior;
- require future maintenance when grid tokens or breakpoints change;
- risk different behavior between the Storybook example and consuming applications; and
- make localization and long-content failures harder to detect.

Using `grid-container` and responsive grid-gap utilities keeps the implementation inside the design system's supported primitives and makes the breakpoint behavior explicit in the markup.

## Accessibility standards

This work targets **WCAG 2.2 Level AA**, specifically **Success Criterion 1.4.10 Reflow**.

At 400% browser zoom, content equivalent to a 1280 CSS-pixel viewport must reflow to a width of 320 CSS pixels without requiring two-dimensional page scrolling, except for content whose meaning inherently requires a two-dimensional layout. Footer navigation, contact details, logos, and social links do not require a two-dimensional layout and therefore need to reflow.

The change also supports the broader accessibility requirements already exercised by Grove's footer accessibility suite:

- semantic footer navigation and list structure;
- keyboard access to footer links and responsive disclosures;
- logical focus order;
- visible focus indicators;
- accessible names for navigation regions, logos, contact links, and social destinations; and
- accurate disclosure states in the big footer's mobile accordion behavior.

Passing an isolated Storybook accessibility scan does not, by itself, guarantee that every application using Grove conforms to WCAG. Applications must still test their assembled footer with their own content, translations, landmarks, and surrounding layout. This change ensures Grove's provided primitive does not introduce horizontal overflow before application content is added.

## Regression coverage

The footer accessibility specification now includes a focused responsive-layout contract for every Storybook variant:

- Default;
- Big; and
- Slim.

Each case:

1. sets the browser viewport to 320 by 800 CSS pixels;
2. loads the corresponding Storybook story;
3. reads the root document's `clientWidth` and `scrollWidth`; and
4. asserts that `scrollWidth` is less than or equal to `clientWidth`.

Testing the root document is intentional. A component-level bounding-box assertion would not detect every negative margin or descendant that increases the page's scrollable area. Comparing the document dimensions verifies the user-visible outcome: the footer does not create horizontal page scrolling.

The test is colocated with the footer accessibility suite because responsive reflow is an accessibility requirement and because the existing suite already exercises each supported footer variant in a real browser.

## Scope

This pull request changes only:

- `src/stories/components/Footer/Footer.ts`; and
- `src/tests/components/footer/accessibility/footer.accessibility.spec.ts`.

It does not:

- change footer content, labels, destinations, or variants;
- redesign desktop or tablet footer layouts;
- add custom CSS;
- alter Grove grid tokens or breakpoints;
- modify the documentation-site footer in `newjersey/njwds-docs`;
- change application-specific footer implementations; or
- use overflow clipping as a substitute for responsive layout.

The separate `newjersey/njwds-docs` footer work remains independent because that repository owns the Grove documentation site's application shell. This pull request owns the reusable Storybook footer primitive consumed by applications.

## Verification

The branch was verified with:

```sh
npm run format:check
npm run lint
npm test
npm run grove:build
npm run storybook:build
npm run test:accessibility
npm run test:visual
```

Results:

- formatting passes;
- linting completes with no errors and the repository's four existing `.storybook/preview.ts` warnings;
- unit tests pass;
- the Grove package build passes;
- the Storybook static build passes;
- all 116 accessibility cases pass, including the new 320-pixel footer assertions; and
- all 131 visual regression cases pass without unintended snapshot changes.

## Review guidance

The most important review points are:

1. whether each gutter begins at the same breakpoint as its corresponding multi-column layout;
2. whether the default footer's new `grid-container` matches Grove and USWDS container composition;
3. whether all footer content remains available at 320 CSS pixels without clipping;
4. whether tablet and desktop spacing remains unchanged; and
5. whether the document-level regression assertion is sufficient to prevent recurrence across all variants.
