### PR TITLE
fix: support right-to-left banner layouts

### DIFF
--- a/src/sass/theme/nj-banner/nj-banner.scss
+++ b/src/sass/theme/nj-banner/nj-banner.scss
@@ -32,26 +32,30 @@
       @media (min-width: 46rem) {
         display: inline;
       }
-      @include u-margin-right(1);
-      @include u-padding-right(1);
-      @include u-border-right(1px);
+      margin-inline-end: units(1);
+      padding-inline-end: units(1);
+      border-inline-end: 1px solid;
 
       &:last-child {
         display: inline;
-        @include u-margin-right(0);
-        @include u-padding-right(0);
-        @include u-border-right(0);
+        margin-inline-end: 0;
+        padding-inline-end: 0;
+        border-inline-end: 0;
       }
     } // li
 
     &-seal {
-      padding-right: units(1);
+      padding-inline-end: units(1);
     } // .nj-banner__header-seal
   } // .nj-banner__header
 
   &__inner {
     @include grid-row;
     @include u-flex("align-center");
-    padding-right: units(0);
+    padding-inline-end: 0;
   } // .nj-banner__inner
+
+  &__mail-icon {
+    margin-inline-end: units(0.5);
+  }
 }

--- a/src/stories/components/Banner/Banner.stories.ts
+++ b/src/stories/components/Banner/Banner.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/web-components-vite";
+import { html } from "lit";
 
 import { BannerComponent, type BannerProps } from "./Banner";
 
@@ -14,6 +15,14 @@ export default meta;
 type Story = StoryObj<BannerProps>;
 
 export const Default: Story = {
+  args: {
+    governor: commonData.gov,
+    ltgovernor: commonData.govlt,
+  },
+};
+
+export const RightToLeft: Story = {
+  render: (args) => html`<div dir="rtl">${BannerComponent(args)}</div>`,
   args: {
     governor: commonData.gov,
     ltgovernor: commonData.govlt,

--- a/src/stories/components/Banner/Banner.ts
+++ b/src/stories/components/Banner/Banner.ts
@@ -34,7 +34,7 @@ export const BannerComponent = ({ governor, ltgovernor }: BannerProps) => {
                   rel="noopener"
                 >
                   <svg
-                    class="usa-icon usa-icon--size-3 nj-banner__mail-icon margin-right-05"
+                    class="usa-icon usa-icon--size-3 nj-banner__mail-icon"
                     role="img"
                     aria-hidden="true"
                     focusable="false"

--- a/src/tests/components/banner/banner.accessibility.spec.ts
+++ b/src/tests/components/banner/banner.accessibility.spec.ts
@@ -1,14 +1,72 @@
+import { expect, test } from "@playwright/test";
+import { DEFAULT_VIEWPORT, NARROW_VIEWPORT, STORYBOOK_URL } from "../../../utils/config";
 import { runA11ySuite } from "../../../utils/runA11ySuite";
+
+const RTL_STORY_URL = `${STORYBOOK_URL}/iframe.html?id=components-banner--right-to-left&viewMode=story`;
 
 const TEST_CASES = [
   {
     name: "default",
     url: `/iframe.html?id=components-banner--default&viewMode=story`,
   },
+  {
+    name: "right to left",
+    url: `/iframe.html?id=components-banner--right-to-left&viewMode=story`,
+  },
 ];
+
+const RTL_VIEWPORTS = [
+  { name: "narrow", ...NARROW_VIEWPORT },
+  { name: "wide", ...DEFAULT_VIEWPORT },
+] as const;
 
 runA11ySuite({
   suiteName: "Banner",
   include: ".nj-banner",
   cases: TEST_CASES,
+});
+
+test.describe("Banner right-to-left layout", () => {
+  for (const viewport of RTL_VIEWPORTS) {
+    test(`uses logical spacing without overflow at the ${viewport.name} viewport`, async ({
+      page,
+    }) => {
+      await page.setViewportSize(viewport);
+      await page.goto(RTL_STORY_URL);
+
+      const bannerItems = page.locator(".nj-banner__header li");
+      const firstItem = bannerItems.first();
+      const lastItem = bannerItems.last();
+      const seal = page.locator(".nj-banner__header-seal");
+      const mailIcon = page.locator(".nj-banner__mail-icon");
+
+      await expect(page.locator('[dir="rtl"]')).toHaveCount(1);
+      await expect(bannerItems).toHaveCount(2);
+      await expect(firstItem).toHaveCSS("margin-inline-end", "8px");
+      await expect(firstItem).toHaveCSS("padding-inline-end", "8px");
+      await expect(firstItem).toHaveCSS("border-inline-end-width", "1px");
+      await expect(firstItem).toHaveCSS("border-left-width", "1px");
+      await expect(firstItem).toHaveCSS("border-right-width", "0px");
+      await expect(lastItem).toHaveCSS("margin-inline-end", "0px");
+      await expect(lastItem).toHaveCSS("padding-inline-end", "0px");
+      await expect(lastItem).toHaveCSS("border-inline-end-width", "0px");
+      await expect(seal).toHaveCSS("padding-inline-end", "8px");
+      await expect(seal).toHaveCSS("padding-left", "8px");
+      await expect(seal).toHaveCSS("padding-right", "0px");
+      await expect(mailIcon).toHaveCSS("margin-inline-end", "4px");
+      await expect(mailIcon).toHaveCSS("margin-left", "4px");
+      await expect(mailIcon).toHaveCSS("margin-right", "0px");
+
+      if (viewport.name === "narrow") {
+        await expect(firstItem).toBeHidden();
+      } else {
+        await expect(firstItem).toBeVisible();
+      }
+
+      const hasHorizontalOverflow = await page.evaluate(
+        () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+      );
+      expect(hasHorizontalOverflow).toBe(false);
+    });
+  }
 });


### PR DESCRIPTION
## Summary

This change makes the Grove 'official site banner' direction-aware by replacing physical right-side spacing and borders with logical inline properties.

It also adds a dedicated right-to-left Storybook story, axe coverage, and narrow/wide visual baselines so RTL behavior becomes a maintained component contract rather than an untested side effect.

The default left-to-right banner content and visual presentation remain unchanged.

## Problem

The banner currently encodes its layout with physical right-side declarations:

- right margin between header links;
- right padding beside separators;
- right borders between links;
- right padding after the state seal;
- right padding on the banner inner container; and
- the `margin-right-05` utility on the mail icon.

Those declarations assume that content always flows from left to right.

When the banner appears in an Arabic, Hebrew, or other right-to-left document, the logical trailing edge is the left side. Physical `right` rules do not follow that change in writing direction, so spacing and separators remain attached to the wrong side of the content.

This can produce:

- separators preceding the wrong link;
- uneven spacing between the seal, links, and icon;
- a layout that looks left-to-right even when the document is right-to-left; and
- application-specific CSS patches that detach consuming sites from Grove.

The existing Storybook and browser suites covered only the default left-to-right presentation, so this regression class was not visible in component review.

## Implementation

### Logical link spacing and separators

The banner link rules now use:

```scss
margin-inline-end: units(1);
padding-inline-end: units(1);
border-inline-end: 1px solid;
```

The last link resets those same logical properties.

`inline-end` resolves to the right side in a left-to-right context and the left side in a right-to-left context. The banner therefore retains its existing English layout while adapting automatically to the surrounding writing direction.

### Logical seal and container spacing

The state seal and inner banner container now use:

```scss
padding-inline-end
```

instead of `padding-right`.

This keeps the spacing associated with the trailing edge of the content rather than a fixed physical side.

### Application-owned mail icon class

The Storybook markup removes the physical USWDS `margin-right-05` utility from the mail icon.

The existing `nj-banner__mail-icon` class now supplies:

```scss
margin-inline-end: units(0.5);
```

This preserves the design token and spacing value while allowing the icon-to-label relationship to mirror in RTL layouts.

### RTL Storybook state

The new `RightToLeft` story renders the same banner primitive inside:

```html
<div dir="rtl">
```

The story intentionally changes only writing direction. It does not introduce translated content, which keeps the visual regression focused on layout behavior rather than copy review.

## Why logical properties

Logical properties are preferable to separate LTR and RTL overrides because they:

- express the semantic relationship between adjacent content;
- adapt automatically to the nearest writing direction;
- avoid duplicated selector branches;
- preserve Grove spacing tokens;
- reduce application-specific overrides; and
- continue to work when the component is embedded in a directionally isolated section.

No JavaScript direction detection is needed. The browser resolves the logical properties from the document or container's `dir` value.

## Accessibility and internationalization standards

This change supports Grove's WCAG 2.2 Level AA and multilingual implementation goals.

Relevant requirements include:

- **1.3.2 Meaningful Sequence:** visual separators and spacing follow the content's reading order.
- **1.4.10 Reflow:** the banner continues to adapt across narrow and wide viewports without direction-specific fixed positioning.
- **1.4.12 Text Spacing:** spacing is expressed without clipping or fixing text into direction-specific boxes.
- **2.4.4 Link Purpose (In Context):** the existing banner links and labels remain intact in either direction.

The change also follows internationalization guidance to prefer CSS logical properties over physical left/right declarations for direction-sensitive layout.

Consuming applications remain responsible for:

- setting the correct page or container `dir`;
- setting the correct document `lang`;
- providing approved translated banner content;
- preserving the official banner wording and link destinations; and
- testing the assembled page with its actual fonts and translations.

## Regression coverage

The RTL story is added to both Grove browser suites.

### Accessibility

The banner axe suite now scans:

- the default left-to-right story; and
- the right-to-left story.

This verifies that the additional composition does not introduce detectable semantic, contrast, or interactive-control violations.

### Visual regression

The visual suite captures the RTL story at the same narrow and wide viewports used for the default banner.

Two reviewed baselines are included:

- `Banner-right-to-left-narrow.png`; and
- `Banner-right-to-left-wide.png`.

These snapshots protect the placement of separators, seal spacing, link ordering, and icon spacing across responsive layouts.

## Verification

The branch was verified with:

```sh
npm run format:check
npm run lint
npm test
npm run grove:build
npm run storybook:build
npm run test:accessibility
npm run test:visual
```

Results:

- formatting passes;
- linting completes without errors, retaining only the repository's existing `.storybook/preview.ts` warnings;
- unit tests pass;
- Grove and Storybook builds pass;
- all 114 accessibility cases pass; and
- all 133 visual cases pass, including the two new RTL baselines.

## Scope and non-goals

This pull request changes only:

- the banner's direction-sensitive Sass;
- the mail icon's spacing class;
- one Storybook story;
- banner accessibility and visual case lists; and
- the two intentional visual baselines.

It does not:

- translate the official banner content;
- alter banner wording, links, or information architecture;
- change the state seal asset;
- redesign the mobile or desktop banner;
- add runtime JavaScript for direction detection;
- modify unrelated USWDS utilities; or
- change application-specific banner wrappers.

## Review guidance

Reviewers should focus on:

1. whether every changed physical property is direction-sensitive;
2. whether `inline-end` preserves the current LTR layout and correctly mirrors RTL;
3. whether the new mail-icon class retains Grove token spacing;
4. whether the RTL snapshots show correct separator and content ordering at both viewports; and
5. whether any remaining banner declarations still assume a physical left or right edge.
