### PR TITLE
feat: compose header and language selector

### DIFF
--- a/src/stories/components/Header/Header.stories.ts
+++ b/src/stories/components/Header/Header.stories.ts
@@ -34,3 +34,11 @@ export const Extended: Story = {
     variant: "Extended",
   },
 };
+
+export const WithLanguageSelector: Story = {
+  args: {
+    languageSelector: true,
+    megamenu: false,
+    variant: "Default",
+  },
+};

--- a/src/stories/components/Header/Header.ts
+++ b/src/stories/components/Header/Header.ts
@@ -1,14 +1,18 @@
 import { html } from "lit";
 
+import { LanguageSelector } from "../LanguageSelector/LanguageSelector";
+
 export interface HeaderProps {
   variant: "Default" | "Extended";
   megamenu: boolean;
+  languageSelector?: boolean;
   toggleValue?: string;
 }
 
-export const Header = ({ variant, megamenu, toggleValue }: HeaderProps) => {
+export const Header = ({ variant, megamenu, languageSelector, toggleValue }: HeaderProps) => {
   // Creates a unique ID for toggles to work for "docs" view in Storybook
   const instanceId = toggleValue ?? `acc-${crypto.randomUUID()}`;
+  const navigationId = `primary-navigation-${instanceId}`;
 
   const searchform = html`
     <form class="usa-search usa-search--small" role="search">
@@ -24,7 +28,7 @@ export const Header = ({ variant, megamenu, toggleValue }: HeaderProps) => {
   `;
 
   const closeButton = html`
-    <button class="usa-nav__close" aria-label="Close navigation">
+    <button class="usa-nav__close" aria-label="Close navigation" aria-controls="${navigationId}">
       <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
         <use href="./img/sprite.svg#close"></use>
       </svg>
@@ -106,6 +110,13 @@ export const Header = ({ variant, megamenu, toggleValue }: HeaderProps) => {
   `;
 
   const menuHtml = megamenu === true ? megaMenuHtml : simpleMenuHtml;
+  const languageSelectorHtml = languageSelector
+    ? LanguageSelector({
+        pattern: "dropdown",
+        buttonType: "tertiary",
+        icon: true,
+      })
+    : "";
 
   const defaultHTML = html`
     <div class="usa-overlay"></div>
@@ -118,10 +129,10 @@ export const Header = ({ variant, megamenu, toggleValue }: HeaderProps) => {
             >
           </div>
           <!--usa-logo-->
-          <button class="usa-menu-btn">Menu</button>
+          <button class="usa-menu-btn" aria-controls="${navigationId}">Menu</button>
         </div>
         <!--/.usa-navbar-->
-        <nav aria-label="Primary navigation" class="usa-nav">
+        <nav id="${navigationId}" aria-label="Primary navigation" class="usa-nav">
           ${closeButton}
           <ul class="usa-nav__primary usa-accordion">
             <li class="usa-nav__primary-item">${menuHtml}</li>
@@ -131,6 +142,9 @@ export const Header = ({ variant, megamenu, toggleValue }: HeaderProps) => {
             <li class="usa-nav__primary-item">
               <a class="usa-nav__link" href="#!"><span>Link</span></a>
             </li>
+            ${languageSelector
+              ? html`<li class="usa-nav__primary-item">${languageSelectorHtml}</li>`
+              : ""}
           </ul>
           ${searchform}
         </nav>
@@ -151,10 +165,10 @@ export const Header = ({ variant, megamenu, toggleValue }: HeaderProps) => {
             >
           </div>
           <!--/.usa-logo-->
-          <button class="usa-menu-btn">Menu</button>
+          <button class="usa-menu-btn" aria-controls="${navigationId}">Menu</button>
         </div>
         <!--/.usa-navbar-->
-        <nav aria-label="Primary navigation" class="usa-nav">
+        <nav id="${navigationId}" aria-label="Primary navigation" class="usa-nav">
           <div class="usa-nav__inner">
             ${closeButton}
             <ul class="usa-nav__primary usa-accordion">
@@ -165,6 +179,9 @@ export const Header = ({ variant, megamenu, toggleValue }: HeaderProps) => {
               <li class="usa-nav__primary-item">
                 <a class="usa-nav__link" href="#!"><span>Link</span></a>
               </li>
+              ${languageSelector
+                ? html`<li class="usa-nav__primary-item">${languageSelectorHtml}</li>`
+                : ""}
             </ul>
             <!--/.usa-nav__primary -->
             <div class="usa-nav__secondary">

--- a/src/tests/components/header/accessibility/header.accessibility.spec.ts
+++ b/src/tests/components/header/accessibility/header.accessibility.spec.ts
@@ -1,4 +1,8 @@
+import { expect, test } from "@playwright/test";
+import { DEFAULT_VIEWPORT, NARROW_VIEWPORT, STORYBOOK_URL } from "../../../../utils/config";
 import { runA11ySuite } from "../../../../utils/runA11ySuite";
+
+const COMPOSED_HEADER_URL = `${STORYBOOK_URL}/iframe.html?id=components-header--with-language-selector&viewMode=story`;
 
 const TEST_CASES = [
   {
@@ -9,10 +13,81 @@ const TEST_CASES = [
     name: "extended",
     url: `/iframe.html?id=components-header--extended&viewMode=story`,
   },
+  {
+    name: "with language selector",
+    url: `/iframe.html?id=components-header--with-language-selector&viewMode=story`,
+  },
 ];
 
 runA11ySuite({
   suiteName: "Header",
   include: ".usa-header",
   cases: TEST_CASES,
+});
+
+test.describe("Header disclosure composition", () => {
+  test("connects controls and keeps the desktop composition visible", async ({ page }) => {
+    await page.setViewportSize(DEFAULT_VIEWPORT);
+    await page.goto(COMPOSED_HEADER_URL);
+
+    const navigation = page.locator(".usa-nav");
+    const languageButton = page.locator(".usa-language__link");
+    const languageItem = navigation.locator(".usa-nav__primary-item").filter({
+      has: languageButton,
+    });
+    const search = navigation.locator(".usa-search");
+    const navigationId = await navigation.getAttribute("id");
+
+    expect(navigationId).not.toBeNull();
+    if (navigationId === null) {
+      throw new Error("The primary navigation must have an ID.");
+    }
+    await expect(page.locator(".usa-menu-btn")).toHaveAttribute("aria-controls", navigationId);
+    await expect(page.locator(".usa-nav__close")).toHaveAttribute("aria-controls", navigationId);
+    await expect(languageItem).toHaveCount(1);
+    await expect(languageButton).toBeVisible();
+    await expect(languageButton).toBeInViewport();
+    await expect(search).toBeVisible();
+
+    const languageButtonBounds = await languageButton.boundingBox();
+    const searchBounds = await search.boundingBox();
+
+    if (languageButtonBounds === null || searchBounds === null) {
+      throw new Error("The language selector and search must have visible bounds.");
+    }
+    expect(languageButtonBounds.x + languageButtonBounds.width).toBeLessThanOrEqual(searchBounds.x);
+
+    const hasHorizontalOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    );
+    expect(hasHorizontalOverflow).toBe(false);
+  });
+
+  test("Escape closes the language selector before the mobile navigation", async ({ page }) => {
+    await page.setViewportSize(NARROW_VIEWPORT);
+    await page.goto(COMPOSED_HEADER_URL);
+
+    const navigation = page.locator(".usa-nav");
+    const languageButton = page.locator(".usa-language__link");
+    const languageOptions = page.locator(".usa-language__submenu");
+
+    await page.locator(".usa-menu-btn").click();
+    await expect(languageButton).toBeVisible();
+    await expect(languageButton).toBeInViewport();
+
+    const hasHorizontalOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    );
+    expect(hasHorizontalOverflow).toBe(false);
+
+    await languageButton.click();
+    await expect(navigation).toBeVisible();
+    await expect(languageOptions).toBeVisible();
+
+    await page.keyboard.press("Escape");
+
+    await expect(languageOptions).toBeHidden();
+    await expect(navigation).toBeVisible();
+    await expect(languageButton).toBeFocused();
+  });
 });


### PR DESCRIPTION
## Summary

This change adds an explicit Storybook composition for a Grove header containing the Grove language selector.

It also strengthens the header disclosure contract by:

- assigning each primary navigation an instance-safe ID;
- connecting both mobile navigation controls to that ID with `aria-controls`;
- placing the language selector in the primary navigation list;
- testing that the selector remains visible in the composed layout; and
- verifying that Escape closes the innermost language disclosure before the surrounding mobile navigation.

The language selector remains optional, and existing default and extended header stories retain their current behavior.

## Problem

Grove provides header and language-selector primitives independently, but there was no maintained example showing how they should behave when composed.

That leaves several integration questions to individual applications:

- where the selector belongs in desktop and mobile header layouts;
- how the mobile menu button and close button identify the navigation they control;
- whether nested disclosures remain visible inside the responsive header;
- which disclosure owns Escape when both the mobile navigation and language menu are open; and
- where focus returns after the inner disclosure closes.

These are not purely visual questions. A composition can pass isolated component tests while becoming inaccessible when the controls share a page.

An initial placement in the basic header's secondary region also demonstrated a concrete layout risk: that region is vertically positioned for a single search control, and adding the selector there can move it outside the viewport. The final implementation places the selector in the semantic primary navigation list, where the header's responsive behavior already manages navigation items.

## Implementation

### Optional composition input

`HeaderProps` now includes:

```ts
languageSelector?: boolean
```

When enabled, the header renders the existing Grove language selector with:

- the dropdown pattern;
- tertiary button styling; and
- the Grove language icon.

The selector is not reimplemented inside the header. The story composes the existing primitive so future language-selector fixes remain centralized.

### Instance-safe navigation ID

The header already derives an instance value from the Storybook `toggleValue` or `crypto.randomUUID()`.

This change uses that value to create:

```text
primary-navigation-<instance>
```

The generated ID is assigned to the `nav` element for both the default and extended variants.

### Mobile control relationships

Both responsive navigation controls now reference the same navigation ID:

- the `Menu` button; and
- the `Close navigation` button.

This makes the controlled region programmatically identifiable and prevents multiple header instances from relying on an ambiguous shared target.

### Language-selector placement

When enabled, the language selector is rendered as its own `usa-nav__primary-item`.

This keeps it:

- inside the primary navigation landmark;
- aligned with existing responsive navigation behavior;
- visible in desktop and mobile layouts; and
- semantically separate from the selector's internal list of language destinations.

The language menu remains an independent nested disclosure rather than merging language options into site navigation.

### Maintained Storybook state

The new `WithLanguageSelector` story uses the default header without a megamenu.

This creates a focused reference for:

- header layout;
- language-selector placement;
- mobile navigation behavior;
- nested disclosure behavior; and
- visual regression.

## Nested disclosure behavior

On a mobile viewport, the composed interaction is:

1. the user opens the site navigation;
2. the user opens the language selector inside it;
3. the user presses Escape;
4. the language submenu closes;
5. the surrounding site navigation remains open; and
6. focus returns to the language-selector button.

Closing the outer navigation at step 3 would hide the element that should receive restored focus and would force the user to reopen the menu before continuing. The innermost disclosure therefore owns the first Escape action.

The behavior is supplied by the existing Grove/USWDS disclosure scripts. This pull request documents and tests the composition rather than introducing a parallel event system.

## Accessibility standards

This work targets WCAG 2.2 Level AA and supports:

- **1.3.1 Info and Relationships:** buttons identify the navigation region they control.
- **2.1.1 Keyboard:** both navigation layers remain keyboard operable.
- **2.1.2 No Keyboard Trap:** users can close the inner disclosure and continue within the open navigation.
- **2.4.3 Focus Order:** focus returns to the control that opened the language selector.
- **2.4.7 Focus Visible:** the restored focus remains on a visible control.
- **2.4.11 Focus Not Obscured (Minimum):** closing the inner disclosure does not hide its trigger by also closing the parent.
- **4.1.2 Name, Role, Value:** menu controls expose the region they control and the existing scripts maintain disclosure state.

Applications remain responsible for:

- providing a skip link before the header;
- identifying the actual current navigation and language destinations;
- supplying localized labels and equivalent routes;
- setting the page-level `lang` and `dir`; and
- testing the assembled header at application breakpoints.

## Relationship to language-selector PR #272

This pull request composes the current language-selector primitive and keeps its own diff limited to header behavior.

PR #272 independently improves the selector's instance IDs, multilingual semantics, and RTL layout. The changes are compatible and should be reviewed together. Merging #272 ensures that pages containing more than one composed selector also receive unique submenu IDs and the improved language metadata.

Neither pull request duplicates the other's implementation.

## Regression coverage

### Accessibility scan

The header axe suite now scans:

- default;
- extended; and
- with language selector.

### Control relationship test

The browser test:

1. locates the composed primary navigation;
2. reads its generated ID;
3. verifies that the menu and close buttons reference that ID; and
4. confirms that the language-selector control is inside the viewport.

The viewport assertion protects against placing optional controls in header regions whose positioning pushes them off-screen.

### Nested Escape test

At a 393 by 800 CSS-pixel viewport, the test:

1. opens the mobile navigation;
2. opens the language submenu;
3. verifies both are visible;
4. presses Escape;
5. verifies the language submenu is hidden;
6. verifies the navigation remains visible; and
7. verifies focus returns to the language button.

### Visual regression

The new story has a reviewed visual baseline:

```text
Header-with-language-selector-default.png
```

## Verification

The branch was verified with:

```sh
npm run format:check
npm run lint
npm test
npm run grove:build
npm run storybook:build
npm run test:accessibility
npm run test:visual
```

Results:

- formatting passes;
- linting completes without errors, retaining only the repository's existing `.storybook/preview.ts` warnings;
- unit tests pass;
- Grove and Storybook builds pass;
- all 116 accessibility cases pass; and
- all 132 visual cases pass.

## Scope and non-goals

This pull request changes only the header primitive, its Storybook states, and its browser coverage.

It does not:

- implement application routing or language persistence;
- add translated header content;
- replace the Grove language selector;
- change the USWDS disclosure engine;
- redesign the default or extended header;
- require every header to display a language selector;
- add a framework-specific stateful wrapper; or
- modify the separate Grove documentation site.

## Review guidance

Reviewers should focus on:

1. whether both mobile controls reference the correct instance-specific navigation;
2. whether the selector belongs in the primary navigation list across header variants;
3. whether the composed control remains visible at desktop and mobile sizes;
4. whether Escape and focus restoration respect the innermost disclosure; and
5. whether the composition remains compatible with the language-selector improvements in #272.
