### PR TITLE
fix: use feedback widget attribute contract

### DIFF
--- a/src/stories/components/FeedbackWidget/FeedbackWidget.ts
+++ b/src/stories/components/FeedbackWidget/FeedbackWidget.ts
@@ -3,10 +3,10 @@ import { html } from "lit";
 export const FeedbackWidget = () => {
   return html`
     <feedback-widget
-      skipEmailStep="false"
+      skip-email-step="false"
       contact-link="https://www.example.com/contact"
-      showCommentDisclaimer="true"
-      onlySaveRatingToAnalytics="false"
+      show-comment-disclaimer="true"
+      only-save-rating-to-analytics="false"
     >
     </feedback-widget>
 

--- a/src/tests/components/feedback-widget/accessibility/feedback-widget.accessibility.spec.ts
+++ b/src/tests/components/feedback-widget/accessibility/feedback-widget.accessibility.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test, type Route } from "@playwright/test";
+import { STORYBOOK_URL } from "../../../../utils/config";
+import { runA11ySuite } from "../../../../utils/runA11ySuite";
+
+const STORY_URL = `/iframe.html?id=components-feedback-widget--default&viewMode=story`;
+
+const fulfillFeedbackRequest = async (route: Route) => {
+  await route.fulfill({
+    body: JSON.stringify({
+      feedbackId: "storybook-feedback-id",
+      message: "Success",
+    }),
+    contentType: "application/json",
+    status: 200,
+  });
+};
+
+runA11ySuite({
+  suiteName: "Feedback widget",
+  include: "feedback-widget",
+  cases: [
+    {
+      name: "default",
+      url: STORY_URL,
+    },
+  ],
+});
+
+test.describe("Feedback widget integration", () => {
+  test("uses documented attributes and completes the mocked comment step", async ({ page }) => {
+    await page.route("https://innovation.nj.gov/app/feedback/dev/**", fulfillFeedbackRequest);
+    await page.goto(`${STORYBOOK_URL}${STORY_URL}`);
+
+    const widget = page.locator("feedback-widget");
+
+    await expect(widget).toHaveAttribute("skip-email-step", "false");
+    await expect(widget).toHaveAttribute("show-comment-disclaimer", "true");
+    await expect(widget).toHaveAttribute("only-save-rating-to-analytics", "false");
+    await expect(widget).not.toHaveAttribute("skipEmailStep");
+
+    await widget.locator("#yesButton").click();
+    await widget.locator('textarea[name="comment"]').fill("The page answered my question.");
+    await widget.locator("#commentSubmit").click();
+
+    await expect(widget.locator("#emailPrompt")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

This change corrects the Grove Storybook feedback-widget integration to use the custom element's documented kebab-case attributes.

It also adds browser coverage that:

- verifies the attributes are present under the names the web component actually reads;
- runs an axe scan against the rendered widget;
- exercises the rating and comment flow;
- intercepts all feedback API requests; and
- confirms the configured email step is reached without transmitting test data.

The feedback-widget package itself is not modified.

## Problem

The Storybook wrapper currently renders three custom-element attributes in camel case:

```html
skipEmailStep="false"
showCommentDisclaimer="true"
onlySaveRatingToAnalytics="false"
```

The `@newjersey/feedback-widget` package reads:

```text
skip-email-step
show-comment-disclaimer
only-save-rating-to-analytics
```

with `getAttribute`.

Custom-element attributes are HTML attributes, not JavaScript object properties. The camel-case names therefore do not satisfy the widget's public contract, and the component falls back to its internal defaults.

This creates a misleading Storybook example:

- the markup appears to configure behavior;
- copied code does not use the documented API;
- changes to the Storybook attribute values may have no effect; and
- integration regressions are not detected because no browser test checks the rendered attributes or user flow.

The widget also sends ratings, comments, and optional email data to the feedback service. Interaction tests must never depend on or write to that live service.

## Implementation

### Correct attribute contract

The Storybook wrapper now renders:

```html
<feedback-widget
  skip-email-step="false"
  contact-link="https://www.example.com/contact"
  show-comment-disclaimer="true"
  only-save-rating-to-analytics="false"
></feedback-widget>
```

`contact-link` was already correct and remains unchanged.

The values remain string values because HTML custom-element attributes are serialized strings and the widget explicitly compares them to `"true"` and `"false"`.

### Accessibility coverage

The new feedback-widget accessibility specification adds the default Storybook story to Grove's shared axe runner.

The scan includes the `feedback-widget` custom element and verifies the rendered component has no detectable accessibility violations in its initial state.

### Integration contract test

The focused Playwright test verifies:

- `skip-email-step="false"` is present;
- `show-comment-disclaimer="true"` is present;
- `only-save-rating-to-analytics="false"` is present;
- the obsolete `skipEmailStep` attribute is absent;
- a positive rating opens the comment step;
- a comment can be submitted; and
- the email prompt appears because the email step is not skipped.

This tests the observable custom-element contract rather than package internals.

### Network isolation

Before the story loads, the test intercepts:

```text
https://innovation.nj.gov/app/feedback/dev/**
```

Every intercepted request receives a deterministic success response with a test-only feedback ID.

This prevents the automated suite from:

- submitting ratings to analytics or storage;
- writing comments to the feedback service;
- depending on external network availability;
- failing because the service is unavailable; or
- polluting production or development feedback data.

Both the rating and comment endpoints are covered by the wildcard route.

## Why this belongs in Grove

Storybook is the copyable integration reference for Grove components.

If its custom-element markup does not match the package contract, every application that copies the example can inherit a silent configuration failure. Correct attributes and an executable browser contract are therefore design-system responsibilities rather than application-specific fixes.

Applications still own:

- whether the widget is enabled;
- which contact URL is appropriate;
- whether rating-only analytics behavior is permitted;
- whether the disclaimer and email step should appear;
- consent, privacy, and retention policy;
- Content Security Policy configuration; and
- locale support.

## Accessibility, privacy, and integration standards

The widget should be evaluated against Grove's WCAG 2.2 Level AA target throughout its complete multi-step flow.

Relevant requirements include:

- **1.3.1 Info and Relationships:** prompts, fields, and messages retain their programmatic relationships.
- **2.1.1 Keyboard:** rating controls, comment submission, and email controls remain keyboard operable.
- **2.4.3 Focus Order:** focus follows the active step and remains usable after state changes.
- **3.3.1 Error Identification:** failed submissions identify the error.
- **3.3.2 Labels or Instructions:** comment and email inputs retain labels and instructions.
- **4.1.2 Name, Role, Value:** custom-element controls expose accurate names, roles, and states.
- **4.1.3 Status Messages:** loading, success, and error feedback remains available to assistive technology.

The integration test does not attempt to prove full WCAG conformance for every widget step. It establishes a maintained initial axe scan and verifies the configured transition into the email step.

From a data-safety perspective, all automated requests are intercepted. Test content is deterministic and never sent to the feedback service.

## Language support

The package currently documents English and Spanish content.

This pull request does not change its language API or add translations. Applications should not assume that the widget can provide an English fallback inside an otherwise unsupported localized page without product and accessibility review.

Language API improvements belong in the `newjersey/feedback-widget` package rather than this Storybook wrapper.

## Verification

The branch was verified with:

```sh
npm run format:check
npx eslint \
  src/stories/components/FeedbackWidget/FeedbackWidget.ts \
  src/tests/components/feedback-widget/accessibility/feedback-widget.accessibility.spec.ts
npx playwright test \
  src/tests/components/feedback-widget/accessibility/feedback-widget.accessibility.spec.ts \
  --project=accessibility
```

Results:

- formatting passes;
- the changed source and test files pass ESLint;
- the default widget axe scan passes; and
- the mocked rating/comment interaction passes.

The complete branch was also previously verified with the Grove unit test, package build, Storybook build, and full accessibility suite before the network-isolation follow-up. The follow-up changes only the test route and response fixture.

The repository-wide lint command currently scans the generated `storybook-static` directory when that build artifact is present. Those generated-file errors are unrelated to this branch; the changed source files pass lint directly.

## Scope and non-goals

This pull request changes only:

- the Storybook feedback-widget markup; and
- the widget's accessibility/integration browser specification.

It does not:

- modify `@newjersey/feedback-widget`;
- change API endpoints or data storage;
- add new widget attributes;
- change the widget's visual design;
- enable the widget in any application;
- add unsupported languages;
- define application privacy policy; or
- send test feedback to a live service.

## Review guidance

Reviewers should focus on:

1. whether every Storybook attribute matches the package README exactly;
2. whether string boolean values match the widget's `getAttribute` comparisons;
3. whether all feedback requests are intercepted before navigation;
4. whether the mocked response covers both rating and comment transitions;
5. whether the test verifies behavior without coupling to implementation details beyond the public DOM contract; and
6. whether any package-level improvement should be tracked separately from this wrapper correction.
