### PR TITLE
fix: add font as custom token

### DIFF
--- a/packages/njwds/src/sass/_uswds-theme.scss
+++ b/packages/njwds/src/sass/_uswds-theme.scss
@@ -114,7 +114,7 @@
   // Global Styles
   $theme-global-paragraph-styles: true,
   $theme-global-link-styles: true,
-  // Custom typeface tokens
+  // Custom Typeface Tokens
   $theme-typeface-tokens: (
       "plus-jakarta-sans": (
         display-name: "Plus Jakarta Sans",

--- a/packages/njwds/src/sass/_uswds-theme.scss
+++ b/packages/njwds/src/sass/_uswds-theme.scss
@@ -114,6 +114,25 @@
   // Global Styles
   $theme-global-paragraph-styles: true,
   $theme-global-link-styles: true,
+  // Custom typeface tokens
+  $theme-typeface-tokens: (
+      "plus-jakarta-sans": (
+        display-name: "Plus Jakarta Sans",
+        cap-height: 745,
+        stack: (
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          Roboto,
+          Helvetica,
+          Arial,
+          sans-serif,
+          "Apple Color Emoji",
+          "Segoe UI Emoji",
+          "Segoe UI Symbol",
+        ),
+      )
+    ),
   // Type Based Font Settings
   $theme-font-type-sans: "public-sans",
   // Role Based Font Settings


### PR DESCRIPTION
This PR addresses https://github.com/newjersey/njwds-project/issues/204. 

The cap height was found [here](https://github.com/tokotype/PlusJakartaSans/blob/18d1cd2f7ea10481919d2f05c1f7064b7307fc26/sources/PlusJakartaSans.glyphs#L1629) and the fallback stack mirrors the other sans fonts supported in USWDS.

Note that I will follow up with doc site updates once this is merged.