### PR TITLE
Add PR template from innovation-repo-template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Link to ticket
+
+This PR resolves {replace with ticket link placeholder}
+
+## What was done?
+
+
+## Accessibility
+
+- [ ] I have made sure this works with a screenreader!
+  - [ ] All actions can be performed by a screenreader user
+  - [ ] All information available to a sighted user is equivalently available via the screenreader
+    - [ ] Headings do not skip levels, and are a good "content summary" of the page
+    - [ ] Keyboard-tabbing/screenreader traversal order makes sense
+    - [ ] All visual information associated with a form field (labels, descriptions, errors) is
+          programmatically associated with that field
+    - [ ] Any user actions trigger screenreader feedback to inform what is happening
+- [ ] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).
+
+## Steps to test
+
+
+## Screenshots (for visual changes)
+
+- Before
+- After
+
+## Notes
+
+<-- Any additional information about changes to approach or new patterns? Any future development
+considerations or refactorings? -->


### PR DESCRIPTION
Hello! I'm working on helping existing projects add the accessibility checklist in [innovation-repo-template](https://github.com/newjersey/innovation-repo-template/blob/main/.github/pull_request_template.md). Proposal to add the full PR template to this repo?

A more exhaustive accessibility checklist would be the [WCAG guidelines](https://www.w3.org/WAI/WCAG22/quickref/?currentsidebar=%23col_customize&levels=aaa). However, this PR checklist aims touch on the [highest-impact gaps](https://njcio.slack.com/archives/C03C7NHK9B4/p1750776115097139) between what engineers already typically do, and what might be missed. Feel free to slim it down/edit as you would find helpful 😊.